### PR TITLE
fix(SOURSD-896): File Upload Changes on Training page

### DIFF
--- a/src/app/[locale]/(logged-in)/user/profile/components/Experience/Experience.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Experience/Experience.tsx
@@ -52,7 +52,7 @@ export default function Experience() {
     isUploading,
     isScanning,
     file,
-  } = useFileUpload("cvUploadFailed");
+  } = useFileUpload("cvUploadFailed", latestCV?.id);
 
   const uploadFile = useUserFileUpload({
     user,

--- a/src/app/[locale]/(logged-in)/user/profile/components/Training/Training.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Training/Training.tsx
@@ -164,7 +164,7 @@ export default function Training() {
 
   const renderActions = useCallback(
     (training: ResearcherTraining) => {
-      const certificateFile = user?.registry?.files[0];
+      const certificateFileId = training.certification_id;
       return (
         <ActionMenu aria-label={`Actions for ${training.training_name}`}>
           <ActionMenuItem
@@ -176,8 +176,10 @@ export default function Training() {
           <ActionMenuItem
             icon={<TaskAltIcon sx={{ color: "menuList1.main" }} />}
             sx={{ color: "menuList1.main" }}
-            onClick={() => certificateFile && downloadFile(certificateFile.id)}
-            disabled={!certificateFile}>
+            onClick={() =>
+              !!certificateFileId && downloadFile(certificateFileId)
+            }
+            disabled={!certificateFileId}>
             {t("viewCertificate")}
           </ActionMenuItem>
           <ActionMenuItem

--- a/src/app/[locale]/(logged-in)/user/profile/components/Training/TrainingForm.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Training/TrainingForm.tsx
@@ -15,7 +15,10 @@ import { PostTrainingsPayload } from "@/services/trainings/types";
 import useFileUpload from "@/hooks/useFileUpload";
 import useUserFileUpload from "@/hooks/useUserFileUpload";
 import { useStore } from "@/data/store";
-import { File as ApplicationFile } from "@/types/application";
+import {
+  File as ApplicationFile,
+  ResearcherTraining,
+} from "@/types/application";
 import FileUploadDetails from "../FileUploadDetails/FileUploadDetails";
 
 const NAMESPACE_TRANSLATION_FORM = "Form.Training";
@@ -32,7 +35,7 @@ interface TrainingFormProps {
   onSubmit: (values: PostTrainingsPayload) => void;
   isPending: boolean;
   onCancel: () => void;
-  initialValues?: TrainingFormValues;
+  initialValues?: ResearcherTraining;
 }
 
 export default function TrainingForm({
@@ -62,7 +65,10 @@ export default function TrainingForm({
     isUploading,
     isScanning,
     file,
-  } = useFileUpload("certificationUploadFailed");
+  } = useFileUpload(
+    "certificationUploadFailed",
+    initialValues?.certification_id
+  );
 
   const { setValue } = useForm();
 

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -605,7 +605,9 @@
     "fileScanOk": "Certification was successfully scanned",
     "fileScanError": "Your Certification file may have a virus",
     "fileNamePlaceholder": "No Certification uploaded",
-    "noFilesUploaded": "No files have been uploaded yet"
+    "noFilesUploaded": "No files have been uploaded yet",
+    "downloading": "Downloading...",
+    "downloadFile": "Download file"
   },
   "NotificationsMenu": {
     "noNotifications": "You have no notifications!",

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -249,7 +249,7 @@ interface ResearcherTraining {
   training_name: string;
   expires_in_years: number;
   id: number;
-  certification_id: number | null;
+  certification_id?: number;
 }
 
 interface ResearcherEmployment {


### PR DESCRIPTION
https://github.com/user-attachments/assets/2ab441e1-f762-44af-a0f3-ed54b1e5e4da

- Remove 2nd certification upload modal
- View certificate linked specifically to selected training entry
- Add optional initialFileId prop to useFileUpload to allow already uploaded file to be fetched

## Issue ticket link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as chore, fix, feature, test, refactor
