### PR TITLE
fix(SOURSD-1042): Webhook URL uniqueness

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Webhooks/Webhooks.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Webhooks/Webhooks.tsx
@@ -72,7 +72,15 @@ export default function Webhooks() {
           event_trigger: yup.number().required(tForm("webhookRequiredInvalid")),
         })
       )
-      .defined(),
+      .defined()
+      .test("receiver_url", tForm("duplicateWebhookError"), (webhooks = []) => {
+        const seen = new Set();
+        for (const { receiver_url } of webhooks) {
+          if (seen.has(receiver_url)) return false;
+          seen.add(receiver_url);
+        }
+        return true;
+      }),
   });
 
   const defaultValues = useMemo(
@@ -167,54 +175,58 @@ export default function Webhooks() {
                     <Grid item xs={12}>
                       <FormFieldArray<WebhookFormData>
                         name="webhooks"
+                        displayLabel={false}
                         boxSx={{
                           display: "grid",
-                          gridTemplateColumns: "3fr 2fr 1fr",
-                          alignItems: "flex-end",
+                          gridTemplateColumns: "10fr 1fr",
                         }}
                         createNewRow={() => ({
                           receiver_url: "",
                           event_trigger: 1,
                         })}
                         renderField={(field, index) => (
-                          <React.Fragment key={field.receiver_url}>
-                            <FormControlHorizontal
-                              label="Receiver URL"
-                              required
-                              labelMd={0}
-                              contentMd={12}
-                              name={`webhooks.${index}.receiver_url`}
-                              placeholder={tForm("name")}
-                              renderField={fieldProps => (
-                                <TextField {...fieldProps} />
-                              )}
-                            />
-                            <FormControlHorizontal
-                              label="Event Trigger"
-                              required
-                              labelMd={0}
-                              contentMd={12}
-                              name={`webhooks.${index}.event_trigger`}
-                              placeholder={tForm("name")}
-                              renderField={fieldProps => (
-                                <Select
-                                  {...fieldProps}
-                                  inputProps={{
-                                    "aria-label": tForm(
-                                      "webhookEventAriaLabel"
-                                    ),
-                                  }}>
-                                  {webhookEventTriggers?.data.map(
-                                    ({ name, id }) => (
-                                      <MenuItem value={id} key={id}>
-                                        {name}
-                                      </MenuItem>
-                                    )
-                                  )}
-                                </Select>
-                              )}
-                            />
-                          </React.Fragment>
+                          <Grid container spacing={2} key={field.receiver_url}>
+                            <Grid item xs={6}>
+                              <FormControlHorizontal
+                                label="Receiver URL"
+                                required
+                                labelMd={0}
+                                contentMd={12}
+                                name={`webhooks.${index}.receiver_url`}
+                                placeholder={tForm("name")}
+                                renderField={fieldProps => (
+                                  <TextField {...fieldProps} />
+                                )}
+                              />
+                            </Grid>
+                            <Grid item xs={6}>
+                              <FormControlHorizontal
+                                label="Event Trigger"
+                                required
+                                labelMd={0}
+                                contentMd={12}
+                                name={`webhooks.${index}.event_trigger`}
+                                placeholder={tForm("name")}
+                                renderField={fieldProps => (
+                                  <Select
+                                    {...fieldProps}
+                                    inputProps={{
+                                      "aria-label": tForm(
+                                        "webhookEventAriaLabel"
+                                      ),
+                                    }}>
+                                    {webhookEventTriggers?.data.map(
+                                      ({ name, id }) => (
+                                        <MenuItem value={id} key={id}>
+                                          {name}
+                                        </MenuItem>
+                                      )
+                                    )}
+                                  </Select>
+                                )}
+                              />
+                            </Grid>
+                          </Grid>
                         )}
                       />
                     </Grid>

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Webhooks/Webhooks.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Webhooks/Webhooks.tsx
@@ -75,11 +75,11 @@ export default function Webhooks() {
       .defined()
       .test("receiver_url", tForm("duplicateWebhookError"), (webhooks = []) => {
         const seen = new Set();
-        for (const { receiver_url } of webhooks) {
-          if (seen.has(receiver_url)) return false;
+        return !webhooks.some(({ receiver_url }) => {
+          if (seen.has(receiver_url)) return true;
           seen.add(receiver_url);
-        }
-        return true;
+          return false;
+        });
       }),
   });
 

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -572,6 +572,7 @@
     "endDateRequiredInvalid": "End date is required",
     "webhookEventAriaLabel": "Webhook Event Trigger",
     "webhookRequiredInvalid": "Webhook event trigger is required",
+    "duplicateWebhookError": "Duplicate webhooks detected! Your webhook receiver URLs should be unique.",
     "addSubsidiary": "Add a subsidiary",
     "subsidiaryName": "Subsidiary name",
     "subsidiaryNamePlaceholder": "Subsidiary name",

--- a/src/utils/find_used_endpoints.py
+++ b/src/utils/find_used_endpoints.py
@@ -1,7 +1,7 @@
 import os
 import re
+import json
 
-# Functions you're looking for
 target_functions = [
     "postRequest",
     "patchRequest",
@@ -100,6 +100,7 @@ def split_at_first_capital(s):
 if __name__ == "__main__":
     project_root = "./"  # Set to your project root
     matches = scan_directory(project_root)
+    output = {}
     for filepath, func, args in matches:
         target_function = filepath.split("/")[-1].split(".ts")[0]
         method = split_at_first_capital(target_function)[0].upper()
@@ -109,8 +110,11 @@ if __name__ == "__main__":
         used = len(matches) > 0
         if used:
             arg1 = args.split(",")[0]
-            root = arg1.split("/")[1]
-            print(method, root)
-            # print(
-            #    f"\nFile: {filepath}\nFunction: {func}\nArguments:\n{args}\n{'-' * 40}"
-            # )
+            root = "/" + arg1.split("/")[1]
+            if root not in output:
+                output[root] = set()
+            output[root].add(method)
+
+    output = {k: sorted(list(v)) for k, v in output.items()}
+    output = dict(sorted(output.items()))
+    print(json.dumps(output, indent=6))


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/9d9a4771-9ef3-452f-b767-e19280dc977b

## Describe your changes

* Limit to unique webhook receiver urls


## Issue ticket link

https://hdruk.atlassian.net/browse/SOURSD-1042


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as chore, fix, feature, test, refactor
