### PR TITLE
feat(REGISTRY-0000): Ingest Feature Flags From API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safepeopleregistry-web",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safepeopleregistry-web",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -33,6 +33,7 @@
         "@storybook/addon-onboarding": "^8.0.5",
         "@tanstack/react-query": "^5.51.23",
         "@tanstack/react-table": "^8.20.6",
+        "@vercel/flags": "3.1.1",
         "@veriff/incontext-sdk": "^2.4.0",
         "axios": "^1.7.7",
         "babel-jest": "^30.0.2",
@@ -53,7 +54,7 @@
         "jwt-decode": "^4.0.0",
         "lodash.get": "^4.4.2",
         "motion": "^11.11.17",
-        "next": "^14.2.18",
+        "next": "^14.2.33",
         "next-intl": "^3.10.0",
         "pretty-bytes": "^6.1.1",
         "react": "^18",
@@ -2117,6 +2118,15 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@edge-runtime/cookies": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-5.0.2.tgz",
+      "integrity": "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -7805,6 +7815,41 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@vercel/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-JM0xXRCHvN5wiSr9C2u6PSbXMnqN/0IXyNEOob6UYWB70vBWVLUKM96wgSuj6orRzRTowItmja2RTYyRvVhuQg==",
+      "deprecated": "This package has been renamed to flags. It offers the same functionality under a new name. Please follow the upgrade guide https://github.com/vercel/flags/blob/main/packages/flags/guides/upgrade-to-v4.md",
+      "license": "MIT",
+      "dependencies": {
+        "@edge-runtime/cookies": "^5.0.2",
+        "jose": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "@sveltejs/kit": "*",
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@veriff/incontext-sdk": {
       "version": "2.4.0",
@@ -17763,6 +17808,15 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-cookie": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "sweetalert2-react-content": "^5.1.0",
     "use-debounce": "^10.0.4",
     "yup": "^1.4.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "@vercel/flags": "3.1.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -43,7 +43,7 @@ export default async function RootLayout({
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
   const features = {
     isTestFeatureEnabled: (await isTestFeatureEnabled()) as boolean,
-    isTestFeatureUserAdmin: (await isTestFeatureUserAdmin()) as boolean
+    isTestFeatureUserAdmin: (await isTestFeatureUserAdmin()) as boolean,
   };
   return (
     <html lang={locale}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -15,7 +15,7 @@ import { PropsWithChildren } from "react";
 import "../sweetalert2-custom.css";
 import "../global.css";
 import IntlClientProvider from "@/context/IntlClientProvider";
-import { isTestFeatureEnabled } from "@/flags";
+import { isTestFeatureEnabled, isTestFeatureUserAdmin } from "@/flags";
 import { FeatureProvider } from "@/components/FeatureProvider";
 import packageJson from "@/../package.json";
 import { RegistryGlobals } from "@/components/RegistryGlobals";
@@ -43,6 +43,7 @@ export default async function RootLayout({
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
   const features = {
     isTestFeatureEnabled: (await isTestFeatureEnabled()) as boolean,
+    isTestFeatureUserAdmin: (await isTestFeatureUserAdmin()) as boolean
   };
   return (
     <html lang={locale}>

--- a/src/components/FeatureProvider/index.tsx
+++ b/src/components/FeatureProvider/index.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useContext, createContext, ReactNode, useMemo } from "react";
+
+const FeatureContext = createContext("features");
+
+export interface FeatureType {
+  [key: string]: boolean;
+}
+
+interface ProviderProps {
+  children: ReactNode;
+  features: FeatureType;
+}
+function FeatureProvider({ children, features }: Readonly<ProviderProps>) {
+  const value = useMemo(() => features, [features]);
+  return (
+    <FeatureContext.Provider value={value as unknown as string}>
+      {children}
+    </FeatureContext.Provider>
+  );
+}
+
+function useFeatures(): FeatureType {
+  return useContext(FeatureContext) as unknown as FeatureType;
+}
+
+export { FeatureProvider, useFeatures };

--- a/src/components/RegistryGlobals/index.tsx
+++ b/src/components/RegistryGlobals/index.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Script from "next/script";
+
+export const RegistryGlobals = ({
+  version,
+  features,
+}: {
+  version: string;
+  features: object;
+}) => {
+  return (
+    <Script id="hdr-globals" strategy="afterInteractive">
+      {`
+        window.RegistryGlobals = {
+          features: ${JSON.stringify(features)},
+          version: ${JSON.stringify(version)}
+        };
+      `}
+    </Script>
+  );
+};

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,9 @@
+import { flag } from "@vercel/flags/next";
+import { createAPIFlagAdapter } from "./utils/apiFlagAdapter";
+
+const apiAdapter = createAPIFlagAdapter();
+
+export const isTestFeatureEnabled = flag({
+  key: "test-feature",
+  adapter: await apiAdapter(),
+});

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,3 +7,8 @@ export const isTestFeatureEnabled = flag({
   key: "test-feature",
   adapter: await apiAdapter(),
 });
+
+export const isTestFeatureUserAdmin = flag({
+  key: "test-feature-user-admin	",
+  adapter: await apiAdapter(),
+});

--- a/src/utils/apiFlagAdapter.ts
+++ b/src/utils/apiFlagAdapter.ts
@@ -1,0 +1,74 @@
+import type { Adapter } from "@vercel/flags";
+
+const { NEXT_PUBLIC_API_V1_SERVER_URL } = process.env;
+
+let cache: Record<string, boolean> | null = null;
+let cacheTimestamp: number | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface Feature {
+  id: number;
+  name: string;
+  value: string;
+  scope: string | null;
+  description: string;
+}
+
+interface FeatureFlagsResponse {
+  message: string;
+  data: {
+    data: Feature[];
+  };
+}
+
+const flattenFlags = (
+  response: FeatureFlagsResponse
+): Record<string, boolean> => {
+  const flags: Record<string, boolean> = {};
+  response.data.data.forEach(feature => {
+    flags[feature.name] = feature.value === "true";
+  });
+  return flags;
+};
+
+const setCache = async (): Promise<Record<string, boolean>> => {
+  try {
+    const res = await fetch(`${NEXT_PUBLIC_API_V1_SERVER_URL}/features`);
+    if (!res.ok) {
+      console.error(`Failed to fetch feature flags: ${res.statusText}`);
+      return {};
+    }
+
+    const json: FeatureFlagsResponse = await res.json();
+    cacheTimestamp = Date.now();
+    return flattenFlags(json);
+  } catch (err) {
+    console.error(
+      "Error fetching feature flags, will retry after cache is stale",
+      err
+    );
+    cacheTimestamp = Date.now();
+    return {};
+  }
+};
+
+const isCacheStale = () => {
+  if (!cacheTimestamp) return true;
+  return Date.now() - cacheTimestamp > CACHE_TTL_MS;
+};
+
+export function createAPIFlagAdapter() {
+  return function apiFlagAdapter<ValueType, EntitiesType>(): Adapter<
+    ValueType,
+    EntitiesType
+  > {
+    return {
+      async decide({ key }): Promise<ValueType> {
+        if (!cache || isCacheStale()) {
+          cache = await setCache();
+        }
+        return (cache[key] as ValueType) ?? (false as ValueType);
+      },
+    };
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Screenshots / videos (if relevant)

## Describe your changes
Ingest feature flags from API using vercel flags

They will need adding to flags.ts as we create them

You an access them server side for example using:
`await isTestFeatureEnabled()` 

They get wrapped in a context provider so for client side you can access them for example using:
`const { isTestFeatureEnabled } = useFeatures();`

Also added in Registry globals so we can see version and enabled features in the dom:

<img width="1036" height="784" alt="image" src="https://github.com/user-attachments/assets/128f8a4e-e0bf-4b45-ac6b-e1be2c2719e0" />



## Issue ticket link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
