### PR TITLE
fix(REGISTRY-2754): Add required asterisk to Organisation/Organisation Size field

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/components/SectorSizeAndWebsite/SectorSizeAndWebsite.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/SectorSizeAndWebsite/SectorSizeAndWebsite.tsx
@@ -57,7 +57,7 @@ export default function SectorSizeAndWebsite() {
           .string()
           .required(tForm("websiteRequiredInvalid"))
           .matches(VALIDATION_URL, tForm("websiteFormatInvalid")),
-        organisation_size: yup.number(),
+        organisation_size: yup.number().required(tForm("organisationSizeRequiredInvalid")),
       }),
     []
   );

--- a/src/app/[locale]/(logged-in)/organisation/profile/components/SectorSizeAndWebsite/SectorSizeAndWebsite.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/SectorSizeAndWebsite/SectorSizeAndWebsite.tsx
@@ -57,7 +57,9 @@ export default function SectorSizeAndWebsite() {
           .string()
           .required(tForm("websiteRequiredInvalid"))
           .matches(VALIDATION_URL, tForm("websiteFormatInvalid")),
-        organisation_size: yup.number().required(tForm("organisationSizeRequiredInvalid")),
+        organisation_size: yup
+          .number()
+          .required(tForm("organisationSizeRequiredInvalid")),
       }),
     []
   );

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -640,6 +640,7 @@
     "organisationSizeAriaLabel": " Organisation Size",
     "organisationSize": "Organisation Size",
     "organisationNameAriaLabel": "Select organisation",
+    "organisationSizeRequiredInvalid": "Organisation size is required",
     "departmentNameAriaLabel": "Select department",
     "toggleOtpPasscodeAriaLabel": "Toggle passcode visibility",
     "togglePasswordAriaLabel": "Toggle password visibility",


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2990" height="1328" alt="image" src="https://github.com/user-attachments/assets/2b4c0271-e13e-47a2-adb7-18225b1a6a78" />

## Describe your changes
This fix makes the organisation size dropdown a required field in the form

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2754

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
