### PR TITLE
fix(REGISTRY-2758): Fix weird render on Organisation / Team

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/components/Delegates/Delegates.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/Delegates/Delegates.tsx
@@ -31,9 +31,6 @@ export default function Delegates() {
   return (
     <LoadingWrapper variant="basic" loading={queryState.isLoading}>
       <PageBody
-        heading={
-          user?.is_delegate === 0 ? null : tProfile("delegatesAdminTitle")
-        }
         description={
           <Markdown>
             {user?.is_delegate === 0

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -108,6 +108,7 @@
       "pending": "Pending Validation",
       "pending_short": "Pending",
       "completed": "Completed",
+      "complete": "Completed",
       "approved": "Approved",
       "undefined": "None",
       "null": "None",
@@ -1601,6 +1602,11 @@
       "removeOrganisationFromProject": "Remove from project",
       "noResultsMessage": "It looks like there are no organisations for any projects.",
       "errorMessage": "Couldn't get the users for this project. Please try again or <contactLink>contact support</contactLink> if the problem persists."
+    },
+    "Status": {
+      "approved": "Approved",
+      "pending": "Pending",
+      "completed": "Completed"
     },
     "projectHasSponsorships": "Sponsor",
     "sponsoredProjectsTitle": "Sponsored Projects",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1603,11 +1603,6 @@
       "noResultsMessage": "It looks like there are no organisations for any projects.",
       "errorMessage": "Couldn't get the users for this project. Please try again or <contactLink>contact support</contactLink> if the problem persists."
     },
-    "Status": {
-      "approved": "Approved",
-      "pending": "Pending",
-      "completed": "Completed"
-    },
     "projectHasSponsorships": "Sponsor",
     "sponsoredProjectsTitle": "Sponsored Projects",
     "ownProjectsTitle": "Projects directly associated with organisation",


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2074" height="930" alt="image" src="https://github.com/user-attachments/assets/31d1c0a6-488a-4ddb-8b86-013fe7f7b878" />

## Describe your changes
Removed the subheading on the delegate view to create consistency in the UI layout and added a missing translation for the "Completed" status chip on the delegate table

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2758

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
