### PR TITLE
fix(REGISTRY-2771): Handle null companies_house_no field while ensuring field remains controlled.

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/components/DigitalIdentifiers/DigitalIdentifiers.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/DigitalIdentifiers/DigitalIdentifiers.tsx
@@ -52,7 +52,7 @@ export default function DigitalIdentifiers() {
   const schema = useMemo(
     () =>
       yup.object().shape({
-        companies_house_no: yup.string(),
+        companies_house_no: yup.string().nullable(),
         isCharity: yup.boolean(),
         charities: yup.array().when("isCharity", {
           is: true,
@@ -86,7 +86,7 @@ export default function DigitalIdentifiers() {
 
   const formOptions = {
     defaultValues: {
-      companies_house_no: organisation?.companies_house_no,
+      companies_house_no: organisation?.companies_house_no || '',
       charities: organisation?.charities.map(
         ({ country, registration_id }) => ({ country, registration_id })
       ),

--- a/src/app/[locale]/(logged-in)/organisation/profile/components/DigitalIdentifiers/DigitalIdentifiers.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/DigitalIdentifiers/DigitalIdentifiers.tsx
@@ -86,7 +86,7 @@ export default function DigitalIdentifiers() {
 
   const formOptions = {
     defaultValues: {
-      companies_house_no: organisation?.companies_house_no || '',
+      companies_house_no: organisation?.companies_house_no || "",
       charities: organisation?.charities.map(
         ({ country, registration_id }) => ({ country, registration_id })
       ),


### PR DESCRIPTION
## Screenshots / videos (if relevant)

https://github.com/user-attachments/assets/4451bfae-7505-4f1e-a4aa-189cb9fcb762

## Describe your changes
Paired with https://github.com/HDRUK/safepeopleregistry-api/pull/725, this fixes the reported bug. Allow the field to be nullable, and handle that correctly. 

## Issue ticket link

https://hdruk.atlassian.net/browse/REGISTRY-2771

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
