### PR TITLE
fix(REGISTRY-2711): Re-order Custodian tabs

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/TabsSections/TabsSections.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/TabsSections/TabsSections.tsx
@@ -48,19 +48,19 @@ export default function TabsSections({ tabId }: TabsSectionsProps) {
           iconPosition="start"
         />
         <Tab
-          icon={<GroupOutlinedIcon />}
-          label={t("users")}
-          href={routes.profileCustodianUsers.path}
-          component={Link}
-          value={PageTabs.USERS}
-          iconPosition="start"
-        />
-        <Tab
           icon={<AssignmentOutlinedIcon />}
           label={t("projects")}
           href={routes.profileCustodianProjects.path}
           component={Link}
           value={PageTabs.PROJECTS}
+          iconPosition="start"
+        />
+        <Tab
+          icon={<GroupOutlinedIcon />}
+          label={t("users")}
+          href={routes.profileCustodianUsers.path}
+          component={Link}
+          value={PageTabs.USERS}
           iconPosition="start"
         />
         <Tab


### PR DESCRIPTION
## Screenshots / videos (if relevant)

## Describe your changes
Re-order the tabs on the Custodian view

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2711?actionerId=712020%3A7d2076c7-2193-4f10-9f74-c1dd575a0ad4&sourceType=assign

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
