### PR TITLE
feat(REGISTRY-2428): Update page metadata

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/configuration/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/configuration/[subTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import SubPage from "../../components/SubPage";
 import { ConfigurationSubTabs, PageTabs } from "../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Configuration | ${SITE_NAME}`,
+  description:
+    "Manage your data custodian configuration and platform settings on Safe People Registry.",
+};
 
 interface ConfigurationPageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/contacts/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/contacts/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Contacts | ${SITE_NAME}`,
+  description: "Manage your data custodian team on Safe People Registry.",
+};
 
 function ContactsPage() {
   return (

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/home/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/home/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Custodian Dashboard | ${SITE_NAME}`,
+  description: "Your data custodian dashboard on Safe People Registry.",
+};
 
 function UsersPage() {
   return (

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import CustodianProjectOrganisation from "./components/CustodianProjectOrganisation";
+
+export const metadata: Metadata = {
+  title: `Project Organisation Details | ${SITE_NAME}`,
+  description:
+    "View the profile and manage validation of an organisation on a project at your custodian.",
+};
 
 interface PageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Project Organisations | ${SITE_NAME}`,
+  description:
+    "View and manage organisations associated with projects governed by your custodian on Safe People Registry.",
+};
 
 function ProjectOrganisationsPage() {
   return (

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/[projectUserId]/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/[projectUserId]/[subTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import { UserSubTabs } from "@/app/[locale]/(logged-in)/data-custodian/profile/consts/tabs";
+import { SITE_NAME } from "@/utils/metadata";
 import CustodianProjectUser from "./components/CustodianProjectUser";
+
+export const metadata: Metadata = {
+  title: `Project User Details | ${SITE_NAME}`,
+  description:
+    "View the profile and manage validation of a researcher on a project governed by your custodian.",
+};
 
 interface PageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Project Users | ${SITE_NAME}`,
+  description:
+    "View and manage researchers associated with projects governed by your custodian on Safe People Registry.",
+};
 
 function ProjectUsersPage() {
   return (

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projects/[id]/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projects/[id]/[subTabId]/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
 import ProjectsSubPageDisplay from "@/app/[locale]/(logged-in)/data-custodian/profile/components/ProjectsSubPageDisplay";
+import { SITE_NAME } from "@/utils/metadata";
 import { ProjectsSubTabs } from "../../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Project Details | ${SITE_NAME}`,
+  description: "View the details and status of a specific research project.",
+};
 
 interface SubPageProjectsProps {
   params: {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projects/page.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projects/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Projects | ${SITE_NAME}`,
+  description:
+    "View and manage research projects at your custodian on Safe People Registry.",
+};
 
 function ProjectsPage() {
   return (

--- a/src/app/[locale]/(logged-in)/organisation/profile/details/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/details/[subTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import SubPage from "../../components/SubPage";
 import { DetailsPageSubTabs, PageTabs } from "../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Organisation Details | ${SITE_NAME}`,
+  description:
+    "View your organisation's profile details on Safe People Registry.",
+};
 
 interface DetailsPageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/organisation/profile/home/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/home/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Organisation Dashboard | ${SITE_NAME}`,
+  description: "Your organisation's Safe People Registry dashboard.",
+};
 
 function UsersPage() {
   return (

--- a/src/app/[locale]/(logged-in)/organisation/profile/projects/[id]/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/projects/[id]/[subTabId]/page.tsx
@@ -1,5 +1,14 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import ProjectsSubPageDisplay from "@/app/[locale]/(logged-in)/organisation/profile/components/ProjectsSubPageDisplay";
 import { ProjectsSubTabs } from "../../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Project Details | ${SITE_NAME}`,
+  description:
+    "View the details and status of a specific research project associated with your organisation.",
+};
+
 interface SubPageProjectsProps {
   params: {
     subTabId: ProjectsSubTabs;

--- a/src/app/[locale]/(logged-in)/organisation/profile/projects/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/projects/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Projects | ${SITE_NAME}`,
+  description:
+    "View research projects associated with your organisation on Safe People Registry.",
+};
 
 function ProjectsPage() {
   return (

--- a/src/app/[locale]/(logged-in)/organisation/profile/team-administration/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/team-administration/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import {
   PageBodyContainer,
   PageColumns,
@@ -8,6 +10,12 @@ import {
 import { useTranslations } from "next-intl";
 import Delegates from "../components/Delegates";
 import { PageTabs, TeamAdminPageSubTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Team Administration | ${SITE_NAME}`,
+  description:
+    "Manage your organisation's team members and their roles on Safe People Registry.",
+};
 
 const NAMESPACE_TRANSLATION = "ProfileOrganisation";
 

--- a/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/[id]/[subSubTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/[id]/[subSubTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { UserSubTabs } from "../../../../consts/tabs";
 import OrganisationUser from "./components";
+
+export const metadata: Metadata = {
+  title: `Researcher Profile | ${SITE_NAME}`,
+  description:
+    "View the profile of a researcher associated with your organisation and perform affiliation.",
+};
 
 interface PageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import SubPage from "../../components/SubPage";
 import { UserAdminPageSubTabs, PageTabs } from "../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `User Administration | ${SITE_NAME}`,
+  description:
+    "View and manage researcher/innovator accounts associated with your organisation on Safe People Registry.",
+};
 
 interface UserAdminPageProps {
   params: {

--- a/src/app/[locale]/(logged-in)/user/profile/affiliations/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/affiliations/page.tsx
@@ -1,7 +1,15 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { responseToQueryState } from "@/utils/query";
 import { putVerifyEmail } from "@/app/actions/affiliations";
 import AffiliationsPage from "../components/AffiliationsPage";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Affiliations | ${SITE_NAME}`,
+  description:
+    "Manage your organisational affiliations on Safe People Registry.",
+};
 
 interface PageProps {
   searchParams?: Promise<{

--- a/src/app/[locale]/(logged-in)/user/profile/experience/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/experience/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Experience | ${SITE_NAME}`,
+  description:
+    "Manage your research experience and professional history on Safe People Registry.",
+};
 
 function ExperiencePage() {
   return (

--- a/src/app/[locale]/(logged-in)/user/profile/home/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/home/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Dashboard | ${SITE_NAME}`,
+  description: "Your Safe People Registry researcher dashboard.",
+};
 
 function UsersPage() {
   return (

--- a/src/app/[locale]/(logged-in)/user/profile/identity/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/identity/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Identity | ${SITE_NAME}`,
+  description: "Manage your identity details on Safe People Registry.",
+};
 
 function IdentityPage() {
   return (

--- a/src/app/[locale]/(logged-in)/user/profile/projects/[id]/[subTabId]/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/projects/[id]/[subTabId]/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import ProjectsSubPageDisplay from "@/app/[locale]/(logged-in)/user/profile/components/ProjectsSubPageDisplay";
 import { ProjectsSubTabs } from "../../../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Project Details | ${SITE_NAME}`,
+  description:
+    "View the details and status of a specific research project on Safe People Registry.",
+};
 
 interface SubPageProjectsProps {
   params: {

--- a/src/app/[locale]/(logged-in)/user/profile/projects/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/projects/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Projects | ${SITE_NAME}`,
+  description:
+    "View the research projects you are associated with on Safe People Registry.",
+};
 
 function ProjectsPage() {
   return (

--- a/src/app/[locale]/(logged-in)/user/profile/training/page.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/training/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Page from "../components/Page";
 import { PageTabs } from "../consts/tabs";
+
+export const metadata: Metadata = {
+  title: `Training | ${SITE_NAME}`,
+  description:
+    "View and manage your training records and certifications on Safe People Registry.",
+};
 
 function TrainingPage() {
   return (

--- a/src/app/[locale]/(logged-out)/about/page.tsx
+++ b/src/app/[locale]/(logged-out)/about/page.tsx
@@ -1,4 +1,5 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { MoreQuestions, PageContainer } from "@/modules";
 import InfoPageWrapper from "@/app/[locale]/(logged-out)/components/InfoPageWrapper";
 import AboutContent from "./components/AboutContent";
@@ -7,9 +8,9 @@ import KeyReferences from "./components/KeyReferences";
 import AuthButtons from "@/organisms/AuthButtons";
 
 export const metadata: Metadata = {
-  title: "About | Safe People Registry",
+  title: `About | ${SITE_NAME}`,
   description:
-    "Learn about the Safe People Registry and how it supports researcher identity verification and data access governance.",
+    "Learn about how Safe People Registry came about, and the communities involved in its creation.",
 };
 
 export default function Page() {

--- a/src/app/[locale]/(logged-out)/contact/page.tsx
+++ b/src/app/[locale]/(logged-out)/contact/page.tsx
@@ -1,11 +1,12 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PageContainer } from "@/modules";
 import InfoPageWrapper from "@/app/[locale]/(logged-out)/components/InfoPageWrapper";
 import ContactContent from "./components/ContactContent";
 
 export const metadata: Metadata = {
-  title: "Contact us | Safe People Registry",
-  description: "Get in touch with the Safe People Registry team.",
+  title: `Contact us | ${SITE_NAME}`,
+  description: "Get in touch with the Safe People Registry team",
 };
 
 export default function Page() {

--- a/src/app/[locale]/(logged-out)/cookie-policy/page.tsx
+++ b/src/app/[locale]/(logged-out)/cookie-policy/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header } from "@/modules";
 import CookiePolicy from "./components/CookiePolicy";
+
+export const metadata: Metadata = {
+  title: `Cookie Policy | ${SITE_NAME}`,
+  description:
+    "Learn how Safe People Registry uses cookies and similar technologies on our website.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/faq/page.tsx
+++ b/src/app/[locale]/(logged-out)/faq/page.tsx
@@ -1,12 +1,13 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PageContainer } from "@/modules";
 import InfoPageWrapper from "@/app/[locale]/(logged-out)/components/InfoPageWrapper";
 import FAQContent from "@/app/[locale]/(logged-out)/faq/components/FAQContent";
 
 export const metadata: Metadata = {
-  title: "FAQs | Safe People Registry",
+  title: `FAQs | ${SITE_NAME}`,
   description:
-    "Frequently asked questions about the Safe People Registry — covering researcher registration, identity verification, and data access governance.",
+    "Frequently asked questions about the Safe People Registry — covering researchers & innovators (the data users), their organisations, and the data custodians making decisions on 'safe people' access.",
 };
 
 export default function Page() {

--- a/src/app/[locale]/(logged-out)/features/page.tsx
+++ b/src/app/[locale]/(logged-out)/features/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header } from "@/modules";
 import FeaturesContent from "./components/FeaturesContent";
+
+export const metadata: Metadata = {
+  title: `Features | ${SITE_NAME}`,
+  description:
+    "Discover how Safe People Registry streamlines researcher identity verification, affiliation management, and data access governance for organisations and custodians.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/get-involved/page.tsx
+++ b/src/app/[locale]/(logged-out)/get-involved/page.tsx
@@ -1,11 +1,13 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PageContainer } from "@/modules";
 import InfoPageWrapper from "@/app/[locale]/(logged-out)/components/InfoPageWrapper";
 import GetInvolvedContent from "./components/GetInvolvedContent";
 
 export const metadata: Metadata = {
-  title: "Get Involved | Safe People Registry",
-  description: "Join the Safe People Registry community",
+  title: `Get Involved | ${SITE_NAME}`,
+  description:
+    "Join the Safe People Registry community and help shape the future of this software. Let your voice be heard.",
 };
 
 export default function Page() {

--- a/src/app/[locale]/(logged-out)/glossary/page.tsx
+++ b/src/app/[locale]/(logged-out)/glossary/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PageContainer } from "@/modules";
 import Glossary from "./components/Glossary";
+
+export const metadata: Metadata = {
+  title: `Glossary | ${SITE_NAME}`,
+  description:
+    "Definitions of key terms used across the Safe People Registry, including researcher roles and data governance concepts.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/how-it-works/page.tsx
+++ b/src/app/[locale]/(logged-out)/how-it-works/page.tsx
@@ -1,9 +1,17 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { MoreQuestions, PageContainer } from "@/modules";
 import Personas from "@/app/[locale]/(logged-out)/how-it-works/components/Personas";
 import ProductVideo from "@/app/[locale]/(logged-out)/how-it-works/components/ProductVideo";
 import About from "@/app/[locale]/(logged-out)/how-it-works/components/About";
 import InfoHero from "@/components/InfoHero";
 import InfoPageWrapper from "@/app/[locale]/(logged-out)/components/InfoPageWrapper";
+
+export const metadata: Metadata = {
+  title: `How It Works | ${SITE_NAME}`,
+  description:
+    "Learn how Safe People Registry connects researchers, their organisations, and data custodians to enable safe, governed access to sensitive research data.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/invite/page.tsx
+++ b/src/app/[locale]/(logged-out)/invite/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import Invite from "./components";
+
+export const metadata: Metadata = {
+  title: `Accept Invitation | ${SITE_NAME}`,
+  description:
+    "Accept your invitation to join Safe People Registry and get started with streamlined 'safe people' validations.",
+};
 
 export default function Page() {
   return <Invite />;

--- a/src/app/[locale]/(logged-out)/privacy-policy/page.tsx
+++ b/src/app/[locale]/(logged-out)/privacy-policy/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header } from "@/modules";
 import PrivaryPolicy from "./components/PrivacyPolicy";
+
+export const metadata: Metadata = {
+  title: `Privacy Policy | ${SITE_NAME}`,
+  description:
+    "Read our privacy policy to understand how Safe People Registry collects, uses, and protects your personal data.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/support/page.tsx
+++ b/src/app/[locale]/(logged-out)/support/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header } from "@/modules";
 import SupportContent from "./components/SupportContent";
+
+export const metadata: Metadata = {
+  title: `Support | ${SITE_NAME}`,
+  description:
+    "Find help and support resources for using Safe People Registry, including guidance for researchers, organisations, and data custodians.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(logged-out)/terms-and-conditions/page.tsx
+++ b/src/app/[locale]/(logged-out)/terms-and-conditions/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header } from "@/modules";
 import TermsAndConditions from "./components/TermsAndConditions";
+
+export const metadata: Metadata = {
+  title: `Terms and Conditions | ${SITE_NAME}`,
+  description:
+    "Read the terms and conditions governing use of the Safe People Registry platform.",
+};
 
 export default function Page() {
   return (

--- a/src/app/[locale]/(user-only)/admin/page.tsx
+++ b/src/app/[locale]/(user-only)/admin/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PageBody, PageBodyContainer, PageSection } from "@/modules";
 import { redirectProfile } from "@/utils/router";
 import { getTranslations } from "next-intl/server";
 import Sections from "./components/Sections/Sections";
+
+export const metadata: Metadata = {
+  title: `Admin | ${SITE_NAME}`,
+  description: "Safe People Registry administration.",
+};
 
 const NAMESPACE_TRANSLATIONS_ADMINISTRATION = "Administration";
 

--- a/src/app/[locale]/(user-only)/keycloak/page.tsx
+++ b/src/app/[locale]/(user-only)/keycloak/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { isLoggedIn } from "@/utils/auth";
 import KeycloakRedirect from "./components/KeycloakRedirect";
+
+export const metadata: Metadata = {
+  title: `Sign In | ${SITE_NAME}`,
+  description: "Sign in to Safe People Registry.",
+};
 
 export default async function Page({
   searchParams,

--- a/src/app/[locale]/(user-only)/register/page.tsx
+++ b/src/app/[locale]/(user-only)/register/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { PendingInvite } from "@/consts/application";
 import { UserGroup } from "@/consts/user";
 import { PageBody } from "@/modules";
@@ -7,6 +9,12 @@ import { cookies } from "next/headers";
 import { getMeUnclaimed } from "@/app/actions/auth";
 import { getPendingInvite, putEmailByInvite } from "@/app/actions/users";
 import Register from "./components/Register";
+
+export const metadata: Metadata = {
+  title: `Register | ${SITE_NAME}`,
+  description:
+    "Create your Safe People Registry account to get started with streamlined 'safe people' validations.",
+};
 
 async function Page({
   searchParams,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { SITE_NAME } from "@/utils/metadata";
 import { Footer, Header, MoreQuestions } from "@/modules";
 import redirectApplication from "@/utils/router";
 import SoursdInfo from "./components/SoursdInfo";
@@ -11,6 +13,12 @@ import YoutubeVideo from "@/components/YoutubeVideo";
 import AuthButtons from "@/organisms/AuthButtons";
 
 const USAGE_HEADING_ID = "homepage-usage-title";
+
+export const metadata: Metadata = {
+  title: SITE_NAME,
+  description:
+    "The Safe People Registry streamlines 'safe people' validation for sensitive data access, helping researchers, their organisations, and data custodians ensure rigorous security standards but with efficient processes.",
+};
 
 export default async function Page() {
   await redirectApplication();

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,1 @@
+export const SITE_NAME = "Safe People Registry";


### PR DESCRIPTION
> AI disclaimer — Claude was used for this. The metadata content (titles and descriptions for each page) was defined manually by the developer; Claude implemented the changes across all 38 page files and created the shared SITE_NAME constant.

## Describe your changes
Adds unique `title` and `description` metadata exports to all page files across the app. Previously, 34 of 38 pages inherited the generic root layout fallback ("Safe People Registry" / "Safe People Registry homepage"), meaning every browser tab and search preview showed identical text regardless of which page was open.

A shared `SITE_NAME` constant has been extracted to `src/utils/metadata.ts` to avoid hardcoding the site name across files. The 4 pages that already had metadata (about, contact, faq, get-involved) have been updated to use the new format and revised copy. All other pages — including all authenticated dashboard pages for researchers, organisations, and data custodians — now have meaningful, page-specific titles.

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2428

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [x] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
