### PR TITLE
fix(REGISTRY-2791): Update endpoint for validation checks

### DIFF
--- a/cypress/support/utils/custodian/manualChecksConfiguration.ts
+++ b/cypress/support/utils/custodian/manualChecksConfiguration.ts
@@ -5,17 +5,18 @@ const hasUnCheckedOnUsersConfigurationManualChecks = () => {
   cy.get('[data-cy="skeleton-checkboxlist"]').should("not.exist", {
     timeout: 20000,
   });
-  cy.get("#1").should("exist").uncheck();
-  cy.contains("span", "Contact details tab: Verify SRO identity").should(
-    "exist"
-  );
-  cy.get('[data-cy="action-menu"]')
-    .find('button[type="button"]')
-    .should("exist");
-  cy.get("#2").should("exist").uncheck();
+  cy.get("#13").should("exist").uncheck();
   cy.contains(
     "p",
     "Contact details tab: Location meets project & policy requirements"
+  ).should("exist");
+  cy.get('[data-cy="action-menu"]')
+    .find('button[type="button"]')
+    .should("exist");
+  cy.get("#14").should("exist").uncheck();
+  cy.contains(
+    "p",
+    "Projects tab: Previous sensitive data project with us in last 2 years at same affiliation?"
   ).should("exist");
   cy.get('[data-cy="action-menu"]')
     .find('button[type="button"]')
@@ -27,8 +28,8 @@ const hasCheckedOnUsersConfigurationManualChecks = () => {
   cy.get('[data-cy="skeleton-checkboxlist"]').should("not.exist", {
     timeout: 20000,
   });
-  cy.get("#1").should("exist").check();
-  cy.get("#2").should("exist").check();
+  cy.get("#13").should("exist").check();
+  cy.get("#14").should("exist").check();
 };
 
 const addManualChecksForUsersConfigurationManualChecks = (title: string) => {
@@ -129,14 +130,14 @@ const hasUnCheckedOnOrganisationConfigurationManualChecks = () => {
   cy.get('[data-cy="skeleton-checkboxlist"]').should("not.exist", {
     timeout: 20000,
   });
-  cy.get("#3").should("exist").uncheck();
+  cy.get("#19").should("exist").uncheck();
   cy.contains("span", "Contact details tab: Verify SRO identity").should(
     "exist"
   );
   cy.get('[data-cy="action-menu"]')
     .find('button[type="button"]')
     .should("exist");
-  cy.get("#4").should("exist").uncheck();
+  cy.get("#21").should("exist").uncheck();
   cy.contains(
     "p",
     "Digital identifiers tab: Check validity & type (Public, Private, etc.)"
@@ -151,8 +152,8 @@ const hasCheckedOnOrganisationConfigurationManualChecks = () => {
   cy.get('[data-cy="skeleton-checkboxlist"]').should("not.exist", {
     timeout: 20000,
   });
-  cy.get("#3").should("exist").check();
-  cy.get("#4").should("exist").check();
+  cy.get("#19").should("exist").check();
+  cy.get("#21").should("exist").check();
 };
 
 const hasAddManualChecksForOrganisationConfigurationManualChecks = () => {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/ValidationChecks/ValidationChecks.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/ValidationChecks/ValidationChecks.tsx
@@ -65,7 +65,7 @@ export default function ValidationChecks() {
     useMutation(putValidationCheckQuery());
 
   const { mutateAsync: createValidationCheck, ...mutateStateCreateCheck } =
-    useMutation(postValidationCheckQuery());
+    useMutation(postValidationCheckQuery(custodianId as number));
 
   const refetch = useCallback(async () => {
     queryStateProjectUser.refetch();

--- a/src/app/actions/accreditations/getAccreditations.ts
+++ b/src/app/actions/accreditations/getAccreditations.ts
@@ -6,10 +6,10 @@ import { handleJsonResponse } from "@/services/requestHelpers";
 import { AccreditationsResponse } from "@/services/accreditations/types";
 
 export default async (
-  resgitryId: number,
+  registryId: number,
   options: ResponseOptions
 ): Promise<ResponseJson<Paged<AccreditationsResponse>>> => {
-  const response = await getRequest(`/accreditations/${resgitryId}`);
+  const response = await getRequest(`/accreditations/${registryId}`);
 
   return handleJsonResponse(response, options);
 };

--- a/src/app/actions/validation_checks/postValidationCheck.ts
+++ b/src/app/actions/validation_checks/postValidationCheck.ts
@@ -7,9 +7,13 @@ import { ValidationCheck } from "@/types/logs";
 import { ResponseOptions, ResponseJson } from "@/types/requests";
 
 export default async (
+  custodianId: number,
   payload: PostValidationCheck,
   options?: ResponseOptions
 ): Promise<ResponseJson<ValidationCheck>> => {
-  const response = await postRequest(`/custodians/validation_checks`, payload);
+  const response = await postRequest(
+    `/custodians/${custodianId}/validation_checks`,
+    payload
+  );
   return handleJsonResponse(response, options);
 };

--- a/src/services/validation_checks/postValidationCheckQuery.ts
+++ b/src/services/validation_checks/postValidationCheckQuery.ts
@@ -1,11 +1,11 @@
 import postValidationCheck from "@/app/actions/validation_checks/postValidationCheck";
 import { PostValidationCheck } from "./types";
 
-export default function postValidationCheckQuery() {
+export default function postValidationCheckQuery(custodianId: number) {
   return {
     mutationKey: ["putValidationCheckQuery"],
     mutationFn: (payload: PostValidationCheck) =>
-      postValidationCheck(payload, {
+      postValidationCheck(custodianId, payload, {
         error: {
           message: "postValidationCheckQueryError",
         },


### PR DESCRIPTION
## Screenshots / videos (if relevant)

## Describe your changes
Use updated endpoint `POST /api/v1/custodians/{custodianId}/validation_checks` from https://github.com/HDRUK/safepeopleregistry-api/pull/740

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2791

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
