### PR TITLE
fix(REGISTRY-2671): Custodian/ User OR Organisation / Automated flags tab | Move Automated Flags tab to be the first tab

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/consts/tabs.ts
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/consts/tabs.ts
@@ -23,21 +23,21 @@ enum ProjectsSubTabs {
 }
 
 enum UserSubTabs {
+  CUSTODIAN_ORG_INFO = "custodian_org_info",
   AFFILIATIONS = "affiliations",
   PROJECTS = "projects",
   IDENTITY = "identity",
   TRAINING_ACCREDITATIONS = "training_accreditations",
-  CUSTODIAN_ORG_INFO = "custodian_org_info",
   HISTORY = "history",
 }
 
 enum OrganisationsSubTabs {
+  AUTOMATED_FLAGS = "automated_flags",
   PEOPLE = "people",
   CONTACT_DETAILS = "contact_details",
   DIGITAL_IDENTIFIERS = "digital_identifiers",
   SECTOR_WEBSITE = "sector_website",
   DATA_SECURITY_COMPLIANCE = "data_security_compliance",
-  AUTOMATED_FLAGS = "automated_flags",
 }
 
 type TabStructure = {

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
@@ -27,6 +27,16 @@ export default function SubTabsSections({
 
   const subTabs = [
     {
+      label: t("organisationsAutomatedFlags"),
+      value: OrganisationsSubTabs.AUTOMATED_FLAGS,
+      href: injectParamsIntoPath(
+        routes.profileCustodianOrganisationsAutomatedFlags.path,
+        {
+          projectOrganisationId,
+        }
+      ),
+    },
+    {
       label: t("organisationsPeople"),
       value: OrganisationsSubTabs.PEOPLE,
       href: injectParamsIntoPath(
@@ -71,16 +81,6 @@ export default function SubTabsSections({
       value: OrganisationsSubTabs.DATA_SECURITY_COMPLIANCE,
       href: injectParamsIntoPath(
         routes.profileCustodianOrganisationsDataSecurityCompliance.path,
-        {
-          projectOrganisationId,
-        }
-      ),
-    },
-    {
-      label: t("organisationsAutomatedFlags"),
-      value: OrganisationsSubTabs.AUTOMATED_FLAGS,
-      href: injectParamsIntoPath(
-        routes.profileCustodianOrganisationsAutomatedFlags.path,
         {
           projectOrganisationId,
         }

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/[projectUserId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectUsers/[projectUserId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
@@ -27,6 +27,16 @@ export default function SubTabsSections({
 
   const subTabs = [
     {
+      label: t("custodianOrgInfo"),
+      value: UserSubTabs.CUSTODIAN_ORG_INFO,
+      href: injectParamsIntoPath(
+        routes.profileCustodianUsersCustodianOrgInfo.path,
+        {
+          projectUserId,
+        }
+      ),
+    },
+    {
       label: t("affiliations"),
       value: UserSubTabs.AFFILIATIONS,
       href: injectParamsIntoPath(
@@ -55,16 +65,6 @@ export default function SubTabsSections({
       value: UserSubTabs.TRAINING_ACCREDITATIONS,
       href: injectParamsIntoPath(
         routes.profileCustodianUsersTrainingAccreditations.path,
-        {
-          projectUserId,
-        }
-      ),
-    },
-    {
-      label: t("custodianOrgInfo"),
-      value: UserSubTabs.CUSTODIAN_ORG_INFO,
-      href: injectParamsIntoPath(
-        routes.profileCustodianUsersCustodianOrgInfo.path,
         {
           projectUserId,
         }

--- a/src/app/[locale]/(logged-in)/organisation/profile/consts/tabs.ts
+++ b/src/app/[locale]/(logged-in)/organisation/profile/consts/tabs.ts
@@ -30,11 +30,11 @@ enum ProjectsSubTabs {
 }
 
 enum UserSubTabs {
+  CUSTODIAN_ORG_INFO = "custodian_org_info",
   AFFILIATIONS = "affiliations",
   PROJECTS = "projects",
   IDENTITY = "identity",
   TRAINING_ACCREDITATIONS = "training_accreditations",
-  CUSTODIAN_ORG_INFO = "custodian_org_info",
   HISTORY = "history",
 }
 


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2796" height="1520" alt="image" src="https://github.com/user-attachments/assets/9914fef1-3b62-4900-ab6a-0eb05dfb7af7" />

<img width="2784" height="1454" alt="image" src="https://github.com/user-attachments/assets/917ebccd-d8e0-49dd-9464-7f967b757c18" />

## Describe your changes
Moved the "automated flags" tab in the users and organisations sub navigation bar to be positioned as the first tab in the custodian view

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2781

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
