### PR TITLE
fix(REGISTRY-2825): Hide Organisations - History tab (for now)

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/[id]/[subSubTabId]/components/SubTabSections/SubTabSections.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/user-administration/[subTabId]/[id]/[subSubTabId]/components/SubTabSections/SubTabSections.tsx
@@ -60,13 +60,13 @@ export default function SubTabsSections({
         }
       ),
     },
-    {
-      label: t("history"),
-      value: UserSubTabs.HISTORY,
-      href: injectParamsIntoPath(routes.profileOrganisationUsersHistory.path, {
-        userId,
-      }),
-    },
+    // {
+    //   label: t("history"),
+    //   value: UserSubTabs.HISTORY,
+    //   href: injectParamsIntoPath(routes.profileOrganisationUsersHistory.path, {
+    //     userId,
+    //   }),
+    // },
   ];
 
   return <SubTabs current={subTabId} tabs={subTabs} />;


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2628" height="1574" alt="image" src="https://github.com/user-attachments/assets/87e5ad84-d32c-4afe-9fd9-684914da397d" />

## Describe your changes
Temporarily hide the "history" tab for the user sub navigation menu in the organisation view/account

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2825

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
