### PR TITLE
fix(REGISTRY-2827): Change initial landing for User on Custodian validation screen

### DIFF
--- a/cypress/support/utils/custodian/users.ts
+++ b/cypress/support/utils/custodian/users.ts
@@ -35,6 +35,7 @@ const hasProjectsTabCustodianUser = () => {
 };
 
 const hasIdentityTabCustodianUser = (user: User) => {
+  cy.clickSubTab("Identity");
   const name = getName(user);
   cy.get(dataCy("page-body")).within(() => {
     cy.contains(name).should("exist");

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Organisations/Organisations.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Organisations/Organisations.tsx
@@ -15,7 +15,7 @@ export default function Organisations() {
   const { custodianId, nameRoute } = useStore(state => ({
     custodianId: state.getCustodian()?.id,
     nameRoute:
-      state.getApplication().routes.profileCustodianOrganisationsPeople,
+      state.getApplication().routes.profileCustodianOrganisationsAutomatedFlags,
   }));
 
   const paginatedQueryParams = useStorePaginatedQueryParams();

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Users/Users.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Users/Users.tsx
@@ -15,7 +15,8 @@ function Users() {
   const tProfile = useTranslations(NAMESPACE_TRANSLATIONS_PROFILE);
   const { custodianId, nameRoute } = useStore(state => ({
     custodianId: state.getCustodian()?.id,
-    nameRoute: state.getApplication().routes.profileCustodianUsersIdentity,
+    nameRoute:
+      state.getApplication().routes.profileCustodianUsersCustodianOrgInfo,
   }));
 
   const paginatedQueryParams = useStorePaginatedQueryParams();

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/projectOrganisations/[projectOrganisationId]/[subTabId]/components/SubTabSections/SubTabSections.tsx
@@ -36,16 +36,7 @@ export default function SubTabsSections({
         }
       ),
     },
-    {
-      label: t("organisationsPeople"),
-      value: OrganisationsSubTabs.PEOPLE,
-      href: injectParamsIntoPath(
-        routes.profileCustodianOrganisationsPeople.path,
-        {
-          projectOrganisationId,
-        }
-      ),
-    },
+
     {
       label: t("organisationsContactDetails"),
       value: OrganisationsSubTabs.CONTACT_DETAILS,
@@ -81,6 +72,16 @@ export default function SubTabsSections({
       value: OrganisationsSubTabs.DATA_SECURITY_COMPLIANCE,
       href: injectParamsIntoPath(
         routes.profileCustodianOrganisationsDataSecurityCompliance.path,
+        {
+          projectOrganisationId,
+        }
+      ),
+    },
+    {
+      label: t("organisationsPeople"),
+      value: OrganisationsSubTabs.PEOPLE,
+      href: injectParamsIntoPath(
+        routes.profileCustodianOrganisationsPeople.path,
         {
           projectOrganisationId,
         }


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2998" height="1562" alt="image" src="https://github.com/user-attachments/assets/35af3085-acd9-4575-a5b7-2ee02833e123" />

<img width="2984" height="1516" alt="image" src="https://github.com/user-attachments/assets/fa25f707-3fd2-4c02-99da-f426e1353bb9" />

## Describe your changes
Change initial landing tab of the sub navigation in custodian "users" and "organisation" tabs to be the "automated flags" tab. Also move the "users" sub navigation tab within "organisation" to the last position. 

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2827

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
