### PR TITLE
feat(REGISTRY-2826): Hide primary email in creation logs

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -1,10 +1,10 @@
 name: Build and deploy to DEV
-run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
+run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 
 on:
   push:
     branches:
-      - dev
+      - feat/registry-2826
 
 jobs:
   setup:
@@ -55,5 +55,5 @@ jobs:
     with:
       env: dev
       chart_path: chart/soursd-web/Chart.yaml
-      git_ref: dev
+      git_ref: feat/registry-2826
     secrets: inherit

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -1,10 +1,10 @@
 name: Build and deploy to DEV
-run-name: ${{ github.actor }} triggered deploy to DEV pipeline
+run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
 
 on:
   push:
     branches:
-      - feat/registry-2826
+      - dev
 
 jobs:
   setup:
@@ -55,5 +55,5 @@ jobs:
     with:
       env: dev
       chart_path: chart/soursd-web/Chart.yaml
-      git_ref: feat/registry-2826
+      git_ref: dev
     secrets: inherit

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1959,8 +1959,7 @@
     "daysSince": "{days} days ago",
     "user": {
       "created": {
-        "title": "Account created",
-        "description": "with primary email \"{attributes_email}\"   "
+        "title": "Account created"
       },
       "updated": {
         "title": "Updated their details",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1959,7 +1959,8 @@
     "daysSince": "{days} days ago",
     "user": {
       "created": {
-        "title": "Account created"
+        "title": "Account created",
+        "description": "The user account was created"
       },
       "updated": {
         "title": "Updated their details",


### PR DESCRIPTION
## Screenshots / videos (if relevant)
Old:
<img width="840" height="255" alt="image" src="https://github.com/user-attachments/assets/2b3686da-cc80-4838-9e81-f952a2c3d6e6" />


New: 
<img width="840" height="194" alt="image" src="https://github.com/user-attachments/assets/0a82b60b-3b25-40b5-9a60-01bf04ca38d6" />

## Describe your changes
Alter wording of a card to hide the email (won't be a problem soon anyway once the BE hides the email itself)


## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2826

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
