### PR TITLE
fix(REGISTRY-2827): Change initial landing for User on Custodian validation screen

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/ProjectsSafePeople/ProjectsSafePeople.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/ProjectsSafePeople/ProjectsSafePeople.tsx
@@ -16,7 +16,7 @@ export default function ProjectsSafePeople() {
   const { custodianId, projectId, route } = useStore(state => ({
     custodianId: state.getCustodian()?.id,
     projectId: state.getCurrentProject().id,
-    route: state.getApplication().routes.profileCustodianUsersProjects,
+    route: state.getApplication().routes.profileCustodianUsersCustodianOrgInfo,
   }));
 
   const paginatedQueryParams = useStorePaginatedQueryParams();


### PR DESCRIPTION
## Screenshots / videos (if relevant)

https://github.com/user-attachments/assets/05b66612-2426-423b-bda0-3fbaaca55f17

## Describe your changes
Ensure that the custodian view landing page is the "automated flags" sub tab when accessing the users table from "safe people" sub tab within the "projects" tab

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2827 

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
