### PR TITLE
fix(REGISTRY-1240): Organisation | Update Delegate view of Organisation profile to be read-only

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/components/NameAndAddress/NameAndAddress.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/NameAndAddress/NameAndAddress.tsx
@@ -17,7 +17,7 @@ import { getUserQuery, putUserQuery } from "@/services/users";
 import { AddressFields } from "@/types/application";
 import { KeyContactFormValues } from "@/types/form";
 import { pick } from "@/utils/json";
-import { Grid, TextField } from "@mui/material";
+import { Grid, TextField, Typography } from "@mui/material";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
@@ -60,6 +60,8 @@ export default function NameAndAddress() {
     user: state.getUser(),
     setUser: state.setUser,
   }));
+
+  const isDelegate = user?.is_delegate === 0;
 
   const {
     isError,
@@ -268,7 +270,13 @@ export default function NameAndAddress() {
                 <Grid size={{ xs: 12 }}>
                   <FormControlWrapper
                     name="sro_profile_uri"
-                    renderField={fieldProps => <TextField {...fieldProps} />}
+                    renderField={fieldProps =>
+                      isDelegate ? (
+                        <TextField {...fieldProps} />
+                      ) : (
+                        <Typography gutterBottom>{fieldProps.value}</Typography>
+                      )
+                    }
                     description={tForm("sroProfileUriDescription")}
                   />
                 </Grid>

--- a/src/app/[locale]/(logged-in)/organisation/profile/components/NameAndAddress/NameAndAddress.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/NameAndAddress/NameAndAddress.tsx
@@ -61,7 +61,7 @@ export default function NameAndAddress() {
     setUser: state.setUser,
   }));
 
-  const isDelegate = user?.is_delegate === 0;
+  const isDelegate = user?.is_delegate === 1;
 
   const {
     isError,
@@ -271,7 +271,7 @@ export default function NameAndAddress() {
                   <FormControlWrapper
                     name="sro_profile_uri"
                     renderField={fieldProps =>
-                      isDelegate ? (
+                      !isDelegate ? (
                         <TextField {...fieldProps} />
                       ) : (
                         <Typography gutterBottom>{fieldProps.value}</Typography>

--- a/src/app/[locale]/(logged-in)/organisation/profile/components/SroFields/SroFields.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/SroFields/SroFields.tsx
@@ -17,13 +17,13 @@ export default function SroFields() {
     user: state.getUser(),
   }));
 
-  const isDelegate = user?.is_delegate === 0;
+  const isDelegate = user?.is_delegate === 1;
 
   const t = useTranslations(NAMESPACE_TRANSLATION);
 
   return (
     <PageSection>
-      {isDelegate ? (
+      {!isDelegate ? (
         <FormSection
           heading={t("keyContactFormTitle")}
           description={<Markdown>{t("keyContactFormDescription")}</Markdown>}>

--- a/src/app/[locale]/(logged-in)/organisation/profile/components/SroFields/SroFields.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/SroFields/SroFields.tsx
@@ -6,7 +6,7 @@ import Markdown from "@/components/Markdown";
 import SelectDepartments from "@/components/SelectDepartments";
 import { useStore } from "@/data/store";
 import { PageSection } from "@/modules";
-import { Grid, TextField } from "@mui/material";
+import { Grid, TextField, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 
 const NAMESPACE_TRANSLATION = "Form";
@@ -17,11 +17,13 @@ export default function SroFields() {
     user: state.getUser(),
   }));
 
+  const isDelegate = user?.is_delegate === 0;
+
   const t = useTranslations(NAMESPACE_TRANSLATION);
 
   return (
     <PageSection>
-      {user?.is_delegate === 0 && (
+      {isDelegate ? (
         <FormSection
           heading={t("keyContactFormTitle")}
           description={<Markdown>{t("keyContactFormDescription")}</Markdown>}>
@@ -64,6 +66,61 @@ export default function SroFields() {
               <FormControlWrapper
                 name="email"
                 renderField={fieldProps => <TextField {...fieldProps} />}
+              />
+            </Grid>
+          </Grid>
+        </FormSection>
+      ) : (
+        <FormSection
+          heading={t("keyContactFormTitle")}
+          description={
+            <Markdown>{t("keyContactFormDescriptionDelegate")}</Markdown>
+          }>
+          <Grid container rowSpacing={3}>
+            <Grid size={{ xs: 12 }}>
+              <FormControlWrapper
+                name="first_name"
+                renderField={fieldProps => (
+                  <Typography>{fieldProps.value}</Typography>
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControlWrapper
+                name="last_name"
+                renderField={fieldProps => (
+                  <Typography>{fieldProps.value}</Typography>
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <FormControlWrapper
+                name="department"
+                renderField={fieldProps => (
+                  <Typography>
+                    {organisation?.departments?.find(
+                      department => department.id === fieldProps.value
+                    )?.name || " "}
+                  </Typography>
+                )}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <FormControlWrapper
+                name="role"
+                renderField={fieldProps => (
+                  <Typography>{fieldProps.value}</Typography>
+                )}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <FormControlWrapper
+                name="email"
+                renderField={fieldProps => (
+                  <Typography>{fieldProps.value}</Typography>
+                )}
               />
             </Grid>
           </Grid>

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -751,6 +751,7 @@
     "arrayAddAnotherButton": "Add Another",
     "keyContactFormTitle": "Senior Responsible Officer (SRO) contact information",
     "keyContactFormDescription": "As a Senior Responsible Officer (SRO), it is required that you have sufficient seniority and relevant responsibility to nominate Delegates from your Organisation to affiliate your employees or students. \n\n\n\n\n\n As an SRO, please provide your individual information here: ",
+    "keyContactFormDescriptionDelegate": "As a Senior Responsible Officer (SRO), it is required that you have sufficient seniority and relevant responsibility to nominate Delegates from your Organisation to affiliate your employees or students. ",
     "departmentName": "Department",
     "departmentNamePlaceholder": "Department Name",
     "departmentNameRequiredInvalid": "Department name is required",

--- a/src/organisms/SroDeclaration/SroDeclaration.tsx
+++ b/src/organisms/SroDeclaration/SroDeclaration.tsx
@@ -15,6 +15,12 @@ const SRO_DELCLARATION_FILE = "/Registry_SRO_Declaration.pdf";
 
 export default function SroDeclaration() {
   const organisation = useStore(state => state.config.organisation);
+  const { user } = useStore(store => ({
+    user: store.getUser(),
+  }));
+
+  const isDelegate = user?.is_delegate === 0;
+
   const t = useTranslations(NAMESPACE_TRANSLATION);
 
   const latestSroFile = organisation?.files
@@ -38,18 +44,19 @@ export default function SroDeclaration() {
           target="_blank">
           {t("downloadTemplate")}
         </Link>
-
-        <FormControlWrapper
-          name="sro_declaration"
-          displayLabel={false}
-          renderField={fieldProps => (
-            <SroDeclarationUploader
-              name="sro_declaration"
-              value={latestSroFile?.id}
-              onChange={fieldProps.onChange}
-            />
-          )}
-        />
+        {isDelegate && (
+          <FormControlWrapper
+            name="sro_declaration"
+            displayLabel={false}
+            renderField={fieldProps => (
+              <SroDeclarationUploader
+                name="sro_declaration"
+                value={latestSroFile?.id}
+                onChange={fieldProps.onChange}
+              />
+            )}
+          />
+        )}
       </Grid>
     </PageSection>
   );

--- a/src/organisms/SroDeclaration/SroDeclaration.tsx
+++ b/src/organisms/SroDeclaration/SroDeclaration.tsx
@@ -19,7 +19,7 @@ export default function SroDeclaration() {
     user: store.getUser(),
   }));
 
-  const isDelegate = user?.is_delegate === 0;
+  const isDelegate = user?.is_delegate === 1;
 
   const t = useTranslations(NAMESPACE_TRANSLATION);
 
@@ -44,7 +44,7 @@ export default function SroDeclaration() {
           target="_blank">
           {t("downloadTemplate")}
         </Link>
-        {isDelegate && (
+        {!isDelegate && (
           <FormControlWrapper
             name="sro_declaration"
             displayLabel={false}


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="998" height="772" alt="image" src="https://github.com/user-attachments/assets/bb8d026e-7158-41d7-b6a0-394630b20902" />

## Describe your changes
Make Senior Responsible Officer (SRO) contact information and SRO declaration read-only on the "profile" page when logged in as a delegate.

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-1240

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
