### PR TITLE
fix(REGISTRY-2776): Fix the column accessor for organisation status in projectUser table

### DIFF
--- a/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
+++ b/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../types/application";
 import {
   renderOrganisationsNameCell,
-  renderOrganisationsStatusCell,
   renderProjectUserNameCell,
   renderStatusCell,
 } from "../../utils/cells";

--- a/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
+++ b/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
@@ -71,11 +71,11 @@ export default function ProjectUsersTable({
         accessorFn: row => getProjectUser(row).project?.title,
       }),
       createDefaultColumn("organisationName", {
-        accessorFn: row => getProjectUser(row).affiliation.organisation,
-        cell: info =>
-          renderOrganisationsNameCell(
-            getProjectUser(info.row.original).affiliation.organisation
-          ),
+        accessorFn: row =>
+          // getProjectOrganisation(row).affiliation?.organisation,
+          (row as CustodianProjectUser)?.custodian_project_organisation
+            ?.model_state?.state?.slug,
+        cell: renderStatusCell,
       }),
       createDefaultColumn("organisationStatus", {
         accessorFn: row => getProjectUser(row),

--- a/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
+++ b/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
@@ -71,16 +71,17 @@ export default function ProjectUsersTable({
         accessorFn: row => getProjectUser(row).project?.title,
       }),
       createDefaultColumn("organisationName", {
+        accessorFn: row => getProjectUser(row).affiliation.organisation,
+        cell: info =>
+          renderOrganisationsNameCell(
+            getProjectUser(info.row.original).affiliation.organisation
+          ),
+      }),
+      createDefaultColumn("organisationStatus", {
         accessorFn: row =>
-          // getProjectOrganisation(row).affiliation?.organisation,
           (row as CustodianProjectUser)?.custodian_project_organisation
             ?.model_state?.state?.slug,
         cell: renderStatusCell,
-      }),
-      createDefaultColumn("organisationStatus", {
-        accessorFn: row => getProjectUser(row),
-        cell: info =>
-          renderOrganisationsStatusCell(getProjectUser(info.row.original)),
       }),
       createDefaultColumn("affiliationStatus", {
         accessorFn: row =>

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -516,6 +516,7 @@ type CustodianProjectUser = WithModelState<{
   created_at: string;
   updated_at: string;
   project_has_user: ProjectUser;
+  custodian_project_organisation?: CustodianProjectOrganisation;
 }>;
 
 type ProjectSponsorship = WithModelState<{

--- a/src/utils/cells.tsx
+++ b/src/utils/cells.tsx
@@ -13,6 +13,7 @@ import SelectRole from "../components/SelectRole";
 import { FileType } from "../consts/files";
 import { PrimaryContactIcon } from "../consts/icons";
 import {
+  CustodianProjectUser,
   CustodianUser,
   File,
   Organisation,
@@ -246,7 +247,10 @@ const renderSelectRoleCell = (
 };
 
 const renderStatusCell = (
-  info: CellContext<User | ProjectUser | Organisation, unknown>
+  info: CellContext<
+    User | ProjectUser | Organisation | CustodianProjectUser,
+    unknown
+  >
 ) => <ChipStatus status={info.getValue() as Status} />;
 
 export {


### PR DESCRIPTION
## Screenshots / videos (if relevant)


https://github.com/user-attachments/assets/ec3e9e94-d29b-46f7-a4b8-4862b63c2802


## Describe your changes
Requires BE changes in the associated BE PR https://github.com/HDRUK/safepeopleregistry-api/pull/750

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2776

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
