### PR TITLE
feat(REGISTRY-2622): User | Change UK Stats Authority tick box to instead be its own table

### DIFF
--- a/cypress/support/utils/custodian/users.ts
+++ b/cypress/support/utils/custodian/users.ts
@@ -53,16 +53,6 @@ const hasTrainingandAccreditationsTabCustodianUser = () => {
   cy.contains("h2", "Training and Accreditations").should("exist");
   cy.contains("h3", "Training history").should("exist");
   cy.contains("h3", "Professional membership history").should("exist");
-  // cy.contains(
-  //   "p",
-  //   "I am a registered Accredited Researcher as published on the UK Statistics Authority website."
-  // ).should("exist");
-  // cy.contains(
-  //   "p",
-  //   "I have signed a User declaration for accessing Digital Economy Act accredited environments."
-  // ).should("exist");
-  // cy.get('[data-testid="AccreditedResearcherIcon"]').should("exist");
-  // cy.get('[data-testid="UserDeclarationIcon"]').should("exist");
 };
 
 const hasAutomatedFlagsTabCustodianUser = () => {

--- a/cypress/support/utils/custodian/users.ts
+++ b/cypress/support/utils/custodian/users.ts
@@ -53,16 +53,16 @@ const hasTrainingandAccreditationsTabCustodianUser = () => {
   cy.contains("h2", "Training and Accreditations").should("exist");
   cy.contains("h3", "Training history").should("exist");
   cy.contains("h3", "Professional membership history").should("exist");
-  cy.contains(
-    "p",
-    "I am a registered Accredited Researcher as published on the UK Statistics Authority website."
-  ).should("exist");
-  cy.contains(
-    "p",
-    "I have signed a User declaration for accessing Digital Economy Act accredited environments."
-  ).should("exist");
-  cy.get('[data-testid="AccreditedResearcherIcon"]').should("exist");
-  cy.get('[data-testid="UserDeclarationIcon"]').should("exist");
+  // cy.contains(
+  //   "p",
+  //   "I am a registered Accredited Researcher as published on the UK Statistics Authority website."
+  // ).should("exist");
+  // cy.contains(
+  //   "p",
+  //   "I have signed a User declaration for accessing Digital Economy Act accredited environments."
+  // ).should("exist");
+  // cy.get('[data-testid="AccreditedResearcherIcon"]').should("exist");
+  // cy.get('[data-testid="UserDeclarationIcon"]').should("exist");
 };
 
 const hasAutomatedFlagsTabCustodianUser = () => {

--- a/cypress/support/utils/user/accreditation.ts
+++ b/cypress/support/utils/user/accreditation.ts
@@ -1,0 +1,77 @@
+import { Accreditation } from "@/types/application";
+import { formatShortDate } from "@/utils/date";
+import { dataCy } from "../common";
+
+const addAccreditation = (accreditation: Accreditation) => {
+  cy.buttonClick("Add accreditated research registration");
+
+  cy.get(dataCy("form-modal")).should("be.visible");
+
+  cy.get("#associated_organisation_name").type(
+    accreditation.associated_organisation_name
+  );
+  cy.get("#id_string").type(accreditation.id_string);
+  cy.dateSelectValue("issue_date", accreditation.issue_date);
+  cy.dateSelectValue("expiry_date", accreditation.expiry_date);
+
+  cy.saveFormClick();
+};
+
+const hasAccreditation = (accreditation: Accreditation) => {
+  cy.getLatestRowOfResults();
+  const row = cy.getResultsRowByValue(
+    accreditation.associated_organisation_name
+  );
+
+  row.within(() => {
+    cy.contains("td", accreditation.associated_organisation_name);
+    cy.contains("td", accreditation.id_string);
+    cy.contains("td", formatShortDate(accreditation.issue_date));
+    cy.contains("td", formatShortDate(accreditation.expiry_date));
+  });
+};
+
+const editAccreditation = (
+  accreditation: Accreditation,
+  updated: Partial<Accreditation>
+) => {
+  cy.getResultsActionMenu(accreditation.associated_organisation_name).click();
+
+  cy.actionMenuClick("View or edit");
+
+  if (updated.associated_organisation_name) {
+    cy.get("#associated_organisation_name")
+      .clear()
+      .type(updated.associated_organisation_name);
+  }
+
+  if (updated.id_string) {
+    cy.get("#id_string").clear().type(updated.id_string);
+  }
+
+  cy.saveFormClick();
+};
+
+const removeAccreditation = (accreditation: Accreditation) => {
+  cy.getLatestRowOfResults();
+  cy.getResultsActionMenu(accreditation.associated_organisation_name).click();
+
+  cy.actionMenuClick("Delete");
+
+  cy.clickAlertModal("Delete", "Warning");
+  cy.clickAlertModal("Close");
+};
+
+const hasRemovedAccreditation = (accreditation: Accreditation) => {
+  cy.getResultsRow()
+    .contains("td", accreditation.associated_organisation_name)
+    .should("not.exist");
+};
+
+export {
+  addAccreditation,
+  editAccreditation,
+  hasRemovedAccreditation,
+  hasAccreditation,
+  removeAccreditation,
+};

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.test.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.test.tsx
@@ -37,7 +37,6 @@ describe("Trainings", () => {
 
     mockUseStore({ user: mockUser });
     (useQuery as jest.Mock).mockReturnValue({
-      // data: mockUserData,
       isLoading: false,
       refetch: jest.fn(),
     });
@@ -55,20 +54,6 @@ describe("Trainings", () => {
     ).toBeInTheDocument();
   });
 
-  it("submits form with correct data", async () => {
-    const mockPutUser = jest.fn();
-    (useMutation as jest.Mock).mockReturnValue({
-      mutateAsync: mockPutUser,
-      isPending: false,
-    });
-
-    render(<Trainings />);
-
-    await act(async () => {
-      fireEvent.click(screen.getByText("Finish"));
-    });
-  });
-
   it("navigates to the correct route after submission", async () => {
     render(<Trainings />);
 
@@ -81,12 +66,6 @@ describe("Trainings", () => {
         ROUTES.profileResearcherHome.path
       );
     });
-  });
-
-  it("updates form when user data changes", async () => {
-    const { rerender } = render(<Trainings />);
-
-    rerender(<Trainings />);
   });
 
   it("has no accessibility violations", async () => {

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.test.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.test.tsx
@@ -27,12 +27,6 @@ jest.mock("@/data/store", () => ({
 
 describe("Trainings", () => {
   const mockUser = mockedUser({ id: 1 });
-  const mockUserData = {
-    data: {
-      uksa_registered: false,
-      declaration_signed: false,
-    },
-  };
 
   const mockRouter = {
     push: jest.fn(),
@@ -43,7 +37,7 @@ describe("Trainings", () => {
 
     mockUseStore({ user: mockUser });
     (useQuery as jest.Mock).mockReturnValue({
-      data: mockUserData,
+      // data: mockUserData,
       isLoading: false,
       refetch: jest.fn(),
     });
@@ -61,17 +55,6 @@ describe("Trainings", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays checkboxes", () => {
-    render(<Trainings />);
-    const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes).toHaveLength(2);
-  });
-
-  it("displays 'Find out more' links", () => {
-    render(<Trainings />);
-    expect(screen.getAllByText("Find out more")).toHaveLength(2);
-  });
-
   it("submits form with correct data", async () => {
     const mockPutUser = jest.fn();
     (useMutation as jest.Mock).mockReturnValue({
@@ -81,19 +64,8 @@ describe("Trainings", () => {
 
     render(<Trainings />);
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(checkboxes[0]);
-    fireEvent.click(checkboxes[1]);
-
     await act(async () => {
       fireEvent.click(screen.getByText("Finish"));
-    });
-
-    await waitFor(() => {
-      expect(mockPutUser).toHaveBeenCalledWith({
-        uksa_registered: true,
-        declaration_signed: true,
-      });
     });
   });
 
@@ -114,28 +86,7 @@ describe("Trainings", () => {
   it("updates form when user data changes", async () => {
     const { rerender } = render(<Trainings />);
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes[0]).not.toBeChecked();
-    expect(checkboxes[1]).not.toBeChecked();
-
-    (useQuery as jest.Mock).mockReturnValue({
-      data: {
-        data: {
-          ...mockUser,
-          uksa_registered: true,
-          declaration_signed: true,
-        },
-      },
-      isLoading: false,
-    });
-
     rerender(<Trainings />);
-
-    await waitFor(() => {
-      const updatedCheckboxes = screen.getAllByRole("checkbox");
-      expect(updatedCheckboxes[0]).toBeChecked();
-      expect(updatedCheckboxes[1]).toBeChecked();
-    });
   });
 
   it("has no accessibility violations", async () => {

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
@@ -73,19 +73,9 @@ export default function Trainings() {
     router.push(ROUTES.profileResearcherHome.path);
   };
 
-  const formOptions = useMemo(
-    () => ({
-      defaultValues: {
-        uksa_registered: !!userData?.data?.uksa_registered,
-        declaration_signed: !!userData?.data?.declaration_signed,
-      },
-    }),
-    [userData?.data?.uksa_registered, userData?.data?.declaration_signed]
-  );
-
   return (
     <LoadingWrapper variant="basic" loading={isLoading}>
-      <Form {...formOptions} onSubmit={handleSubmit} key={userData?.data?.id}>
+      <Form onSubmit={handleSubmit} key={userData?.data?.id}>
         <PageBodyContainer heading={tProfile("trainingTitle")}>
           <PageColumns>
             <PageColumnBody size={{ lg: 8 }}>

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
@@ -19,6 +19,7 @@ import {
   PageSection,
 } from "@/modules";
 import ProfessionalRegistrations from "@/modules/ProfessionalRegistrations";
+import AccreditedResearcherRegs from "@/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs";
 import Training from "@/organisms/Training";
 import { getUserQuery, putUserQuery } from "@/services/users";
 import { EntityType } from "@/types/api";
@@ -101,6 +102,15 @@ export default function Trainings() {
                     user={userData?.data}
                     setHistories={setHistories}
                     getHistories={getHistories}
+                  />
+                </PageSection>
+                <PageSection>
+                  <AccreditedResearcherRegs
+                    variant={EntityType.USER}
+                    user={userData?.data}
+                    setHistories={setHistories}
+                    getHistories={getHistories}
+                    registryId={user.registry_id}
                   />
                 </PageSection>
                 <PageSection>

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
@@ -27,7 +27,6 @@ import { Box } from "@mui/material";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useMemo } from "react";
 
 const NAMESPACE_TRANSLATION_PROFILE = "Profile";
 

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
@@ -123,7 +123,7 @@ export default function Trainings() {
                   />
                 </PageSection>
 
-                <Box sx={{ mt: 1, maxWidth: "50%" }}>
+                {/* <Box sx={{ mt: 1, maxWidth: "50%" }}>
                   <FormControlCheckbox
                     name="uksa_registered"
                     label={tProfile("accreditedResearcherCheckboxLabel")}
@@ -137,9 +137,9 @@ export default function Trainings() {
                       </Link>
                     }
                   />
-                </Box>
+                </Box> */}
 
-                <Box sx={{ mt: 1, maxWidth: "50%" }}>
+                {/* <Box sx={{ mt: 1, maxWidth: "50%" }}>
                   <FormControlCheckbox
                     name="declaration_signed"
                     label={tProfile("userDeclarationCheckboxLabel")}
@@ -153,7 +153,7 @@ export default function Trainings() {
                       </Link>
                     }
                   />
-                </Box>
+                </Box> */}
                 <Box
                   sx={{ display: "flex", justifyContent: "flex-end", mt: 3 }}>
                   <ProfileNavigationFooter

--- a/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/Trainings/Trainings.tsx
@@ -2,7 +2,6 @@
 
 import ErrorMessage from "@/components/ErrorMessage";
 import Form from "@/components/Form";
-import FormControlCheckbox from "@/components/FormControlCheckbox";
 import Guidance from "@/components/Guidance";
 import LoadingWrapper from "@/components/LoadingWrapper";
 import ProfileNavigationFooter from "@/components/ProfileNavigationFooter";
@@ -24,18 +23,13 @@ import Training from "@/organisms/Training";
 import { getUserQuery, putUserQuery } from "@/services/users";
 import { EntityType } from "@/types/api";
 import { User } from "@/types/application";
-import { Box, Link } from "@mui/material";
+import { Box } from "@mui/material";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 
 const NAMESPACE_TRANSLATION_PROFILE = "Profile";
-
-const RESEARCHER_DECLARATION_LINK =
-  "https://uksa.statisticsauthority.gov.uk/digitaleconomyact-research-statistics/better-useofdata-for-research-information-for-researchers/list-of-accredited-researchers-and-research-projects-under-the-research-strand-of-the-digital-economy-act/";
-const USER_DECLARATION_LINK =
-  "https://www.gov.uk/government/publications/digital-economy-act-2017-part-5-codes-of-practice/research-code-of-practice-and-accreditation-criteria";
 
 export default function Trainings() {
   const tProfile = useTranslations(NAMESPACE_TRANSLATION_PROFILE);
@@ -122,38 +116,6 @@ export default function Trainings() {
                     professionalRegistrations={professionalRegistrations}
                   />
                 </PageSection>
-
-                {/* <Box sx={{ mt: 1, maxWidth: "50%" }}>
-                  <FormControlCheckbox
-                    name="uksa_registered"
-                    label={tProfile("accreditedResearcherCheckboxLabel")}
-                    labelCaption={
-                      <Link
-                        href={RESEARCHER_DECLARATION_LINK}
-                        color="primary"
-                        target="_blank"
-                        sx={{ display: "block", mt: 0.5 }}>
-                        {tProfile("findOutMore")}
-                      </Link>
-                    }
-                  />
-                </Box> */}
-
-                {/* <Box sx={{ mt: 1, maxWidth: "50%" }}>
-                  <FormControlCheckbox
-                    name="declaration_signed"
-                    label={tProfile("userDeclarationCheckboxLabel")}
-                    labelCaption={
-                      <Link
-                        href={USER_DECLARATION_LINK}
-                        color="primary"
-                        target="_blank"
-                        sx={{ display: "block", mt: 0.5 }}>
-                        {tProfile("findOutMore")}
-                      </Link>
-                    }
-                  />
-                </Box> */}
                 <Box
                   sx={{ display: "flex", justifyContent: "flex-end", mt: 3 }}>
                   <ProfileNavigationFooter

--- a/src/app/actions/accreditations/deleteAccreditations.ts
+++ b/src/app/actions/accreditations/deleteAccreditations.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { handleJsonResponse } from "@/services/requestHelpers";
+import { deleteRequest } from "@/services/requests";
+import { ResponseJson, ResponseOptions } from "@/types/requests";
+
+export default async (
+  registryId: number,
+  id: number,
+  options: ResponseOptions
+): Promise<ResponseJson<null>> => {
+  const response = await deleteRequest(
+    `/accreditations/${id}/registries/${registryId}`
+  );
+
+  return handleJsonResponse(response, options);
+};

--- a/src/app/actions/accreditations/index.ts
+++ b/src/app/actions/accreditations/index.ts
@@ -1,3 +1,11 @@
-import getAccreditations from "@/app/actions/accreditations/getAccreditations";
+import getAccreditations from "./getAccreditations";
+import deleteAccreditations from "./deleteAccreditations";
+import postAccreditations from "./postAccreditations";
+import putAccreditations from "./putAccreditations";
 
-export { getAccreditations };
+export {
+  getAccreditations,
+  deleteAccreditations,
+  postAccreditations,
+  putAccreditations,
+};

--- a/src/app/actions/accreditations/postAccreditations.ts
+++ b/src/app/actions/accreditations/postAccreditations.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import {
+  PostAccreditationsPayload,
+  PostAccreditationsResponse,
+} from "@/services/accreditations/types";
+import { handleJsonResponse } from "@/services/requestHelpers";
+import { postRequest } from "@/services/requests";
+import { ResponseOptions, ResponseJson } from "@/types/requests";
+
+export default async (
+  registryId: number,
+  payload: PostAccreditationsPayload,
+  options?: ResponseOptions
+): Promise<ResponseJson<PostAccreditationsResponse>> => {
+  const response = await postRequest(
+    `/accreditations/${registryId}`,
+
+    {
+      ...payload,
+    },
+    {
+      headers: {
+        "content-type": "application/json;charset=UTF-8",
+      },
+    }
+  );
+
+  return handleJsonResponse(response, options);
+};

--- a/src/app/actions/accreditations/putAccreditations.ts
+++ b/src/app/actions/accreditations/putAccreditations.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import {
+  PutAccreditationsPayload,
+  PutAccreditationsResponse,
+} from "@/services/accreditations/types";
+import { handleJsonResponse } from "@/services/requestHelpers";
+import { putRequest } from "@/services/requests";
+import { ResponseOptions, ResponseJson } from "@/types/requests";
+
+export default async (
+  id: number,
+  registryId: number,
+  payload: PutAccreditationsPayload,
+  options: ResponseOptions
+): Promise<ResponseJson<PutAccreditationsResponse>> => {
+  const response = await putRequest(
+    `/accreditations/${id}/registries/${registryId}`,
+    payload
+  );
+
+  return handleJsonResponse(response, options);
+};

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -967,7 +967,7 @@
     "memberIdRequiredInvalid": "ID is required",
     "professionalRegistrationsRecords": "Professional memberships records",
     "professionalRegistrationsNoResultsMessage": "You currently have no professional memberships",
-    "professionalRegsitrationsErrorMessage": "There was an error getting your professional memberships. Please try again or contact us at <contactLink></contactLink>",
+    "professionalRegistrationsErrorMessage": "There was an error getting your professional memberships. Please try again or contact us at <contactLink></contactLink>",
     "errorCreateMessage": "There was an error creating your professional memberships. Please try again or contact us at <contactLink></contactLink>",
     "errorPutMessage": "There was an error updating your professional membership. Please try again or contact us at <contactLink></contactLink>",
     "successCreateMessage": "Your professional membership was successfully created",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1240,6 +1240,29 @@
     "cvUploaded": "CV Uploaded",
     "downloadCv": "Download CV"
   },
+  "AccreditedResearcherRegistrations": {
+    "accreditationTitle": "Accredited Researcher Registrations",
+    "publicRegisterLink": "View the public register of accredited researchers",
+    "noResultsMessage": "You currently have no accredited researcher registrations",
+    "buttonText": "Add researcher accreditation",
+    "editAccreditation": "Edit researcher accreditation",
+    "addAccreditation": "Add researcher accreditation",
+    "errorDeleteMessage": "There was an error deleting your accredited researcher registration entry",
+    "successDeleteMessage": "Your training accredited researcher registration entry was successfully deleted"
+  },
+  "AccreditedResearcherRegistrationForm": {
+    "associatedOrganisationName": "Associated organisation name",
+    "id": "ID",
+    "issueDate": "Issue date",
+    "expiryDate": "Expiry date",
+    "cancel": "Cancel",
+    "requiredName": "Associated organisation name is required",
+    "requiredId": "ID is required",
+    "requiredIssueDate": "Issue date is required",
+    "requiredExpiryDate": "Expiry date is required",
+    "issueDateInvalid": "Issue date must be in the past",
+    "expiryDateInvalid": "Expiry date must be after the issue date"
+  },
   "ProfileCompleteStatus": {
     "profileComplete": "Profile complete",
     "uniqueIdPopup": "Your unique id is used by Data Custodians to identify who you are.",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1145,7 +1145,6 @@
     "accreditedResearcherCheckboxLabel": "I am a registered Accredited Researcher as published on the UK Statistics Authority website.",
     "userDeclarationCheckboxLabel": "I have signed a User declaration for accessing Digital Economy Act accredited environments.",
     "checkAccreditedResearcher": "Check Accredited Researcher listing",
-    "findOutMore": "Find out more",
     "employmentEducationPublicationRecord": "Employment, education and publication record",
     "orcidDescription": "Enter your ORCID identifier (if you have one) to help Data Custodians identify you.",
     "orcidFormDescription": "We’ll automatically import your publicly visible employment information to speed up affiliation in the next tab. You can edit this after it’s been pulled in.",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1247,6 +1247,7 @@
     "buttonText": "Add researcher accreditation",
     "editAccreditation": "Edit researcher accreditation",
     "addAccreditation": "Add researcher accreditation",
+    "postAccreditationSuccess": "Research accreditation added successfully",
     "errorDeleteMessage": "There was an error deleting your accredited researcher registration entry",
     "successDeleteMessage": "Your training accredited researcher registration entry was successfully deleted"
   },

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1270,7 +1270,8 @@
     "requiredId": "ID is required",
     "requiredIssueDate": "Issue date is required",
     "requiredExpiryDate": "Expiry date is required",
-    "expiryDateInvalid": "Issue date must be in the past",
+    "issueDateInvalid": "Issue date must be in the past",
+    "expiryDateInvalid": "Expiry date must be in the future",
     "futureRequiredExpiryDate": "Expiry date must be after the issue date"
   },
   "ProfileCompleteStatus": {

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1247,11 +1247,20 @@
     "buttonText": "Add researcher accreditation",
     "editAccreditation": "Edit researcher accreditation",
     "addAccreditation": "Add researcher accreditation",
+    "associatedOrganisationName": "Associated organisation name",
+    "id": "ID",
+    "issueDate": "Issue date",
+    "expiryDate": "Expiry date",
+    "postAccreditationError": "There was a problem submitting your accredited researcher registration. Please try again or <contactLink>contact support</contactLink> if the problem persists.",
     "postAccreditationSuccess": "Research accreditation added successfully",
-    "errorDeleteMessage": "There was an error deleting your accredited researcher registration entry",
-    "successDeleteMessage": "Your training accredited researcher registration entry was successfully deleted"
+    "errorDeleteMessage": "There was an error deleting your accredited researcher registration entry. Please try again or contact us at <contactLink></contactLink>",
+    "successDeleteMessage": "Your training accredited researcher registration entry was successfully deleted",
+    "updateAccreditationSuccess": "Research accreditation updated successfully",
+    "updateAccreditationError": "There was an error updating the accredited researcher registration entry",
+    "viewOrEditAccreditation": "View or Edit",
+    "deleteAccreditation": "Delete"
   },
-  "AccreditedResearcherRegistrationForm": {
+  "AccreditedResearcherRegistrationsForm": {
     "associatedOrganisationName": "Associated organisation name",
     "id": "ID",
     "issueDate": "Issue date",
@@ -1261,8 +1270,8 @@
     "requiredId": "ID is required",
     "requiredIssueDate": "Issue date is required",
     "requiredExpiryDate": "Expiry date is required",
-    "issueDateInvalid": "Issue date must be in the past",
-    "expiryDateInvalid": "Expiry date must be after the issue date"
+    "expiryDateInvalid": "Issue date must be in the past",
+    "futureRequiredExpiryDate": "Expiry date must be after the issue date"
   },
   "ProfileCompleteStatus": {
     "profileComplete": "Profile complete",

--- a/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
+++ b/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
@@ -242,7 +242,7 @@ export default function ProfessionalRegistrations({
         errorMessage={
           <ErrorMessage
             t={tProfessional}
-            key="professionalRegsitrationsErrorMessage"
+            key="professionalRegistrationsErrorMessage"
           />
         }
         total={professionalRegistrations.length}

--- a/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
+++ b/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
@@ -269,7 +269,7 @@ export default function ProfessionalRegistrations({
         </Button>
       )}
 
-      {variant === EntityType.CUSTODIAN && (
+      {/* {variant === EntityType.CUSTODIAN && (
         <>
           <Box
             sx={{
@@ -322,7 +322,7 @@ export default function ProfessionalRegistrations({
             <Typography>{tProfile("userDeclarationCheckboxLabel")}</Typography>
           </Box>
         </>
-      )}
+      )} */}
     </>
   );
 }

--- a/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
+++ b/src/modules/ProfessionalRegistrations/ProfessionalRegistrations.tsx
@@ -3,16 +3,15 @@
 import { StoreUserHistories } from "@/data/store";
 import CreateOutlinedIcon from "@mui/icons-material/CreateOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
-import { Box, Button, Link, Typography } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ErrorMessage from "@/components/ErrorMessage";
-import Icon from "@/components/Icon";
 import { ActionMenu, ActionMenuItem } from "../../components/ActionMenu";
 import Table from "../../components/Table";
-import { AddIcon, RejectIcon, VerifyIcon } from "../../consts/icons";
+import { AddIcon } from "../../consts/icons";
 import useQueryAlerts from "../../hooks/useQueryAlerts";
 import useQueryConfirmAlerts from "../../hooks/useQueryConfirmAlerts";
 import useMutationUpdateProfessionalRegistration from "../../queries/useMutationUpdateProfessionalRegistration";
@@ -31,10 +30,6 @@ import ProfessionalRegistrationsFormModal from "./ProfessionalRegistrationsFormM
 
 const NAMESPACE_TRANSLATION_PROFESSIONAL = "ProfessionalRegistrations";
 const NAMESPACE_TRANSLATION_APPLICATION = "Application";
-const NAMESPACE_TRANSLATION_PROFILE = "Profile";
-
-const UKSA_URL =
-  "https://uksa.statisticsauthority.gov.uk/digitaleconomyact-research-statistics/better-useofdata-for-research-information-for-researchers/list-of-accredited-researchers-and-research-projects-under-the-research-strand-of-the-digital-economy-act/";
 
 interface ProfessionalRegistrationsProps {
   variant: EntityType;
@@ -58,7 +53,6 @@ export default function ProfessionalRegistrations({
   const [isEditMode, setIsEditMode] = useState(false);
   const tProfessional = useTranslations(NAMESPACE_TRANSLATION_PROFESSIONAL);
   const tApplication = useTranslations(NAMESPACE_TRANSLATION_APPLICATION);
-  const tProfile = useTranslations(NAMESPACE_TRANSLATION_PROFILE);
 
   const {
     data: professionalRegistrationsData,
@@ -268,61 +262,6 @@ export default function ProfessionalRegistrations({
           {tProfessional("addProfessionalRegistration")}
         </Button>
       )}
-
-      {/* {variant === EntityType.CUSTODIAN && (
-        <>
-          <Box
-            sx={{
-              p: 0,
-              my: 2,
-              display: "flex",
-              flexDirection: "column",
-            }}>
-            <Box
-              sx={{
-                p: 0,
-                mt: 3,
-                mb: 1,
-                display: "flex",
-                alignItems: "center",
-              }}>
-              <Icon sx={{ mr: 1 }}>
-                {user.uksa_registered ? (
-                  <VerifyIcon data-testid="AccreditedResearcherIcon" />
-                ) : (
-                  <RejectIcon data-testid="AccreditedResearcherIcon" />
-                )}
-              </Icon>
-              <Typography>
-                {tProfile("accreditedResearcherCheckboxLabel")}
-              </Typography>
-            </Box>
-            {!!user.uksa_registered && (
-              <Link href={UKSA_URL} target="_blank">
-                {tProfile("checkAccreditedResearcher")}
-              </Link>
-            )}
-          </Box>
-
-          <Box
-            sx={{
-              p: 0,
-              mt: 3,
-              mb: 2,
-              display: "flex",
-              alignItems: "center",
-            }}>
-            <Icon sx={{ mr: 1 }}>
-              {user.declaration_signed ? (
-                <VerifyIcon data-testid="UserDeclarationIcon" />
-              ) : (
-                <RejectIcon data-testid="UserDeclarationIcon" />
-              )}
-            </Icon>
-            <Typography>{tProfile("userDeclarationCheckboxLabel")}</Typography>
-          </Box>
-        </>
-      )} */}
     </>
   );
 }

--- a/src/modules/ProjectsAddUserForm/ProjectsAddUserForm.tsx
+++ b/src/modules/ProjectsAddUserForm/ProjectsAddUserForm.tsx
@@ -135,7 +135,7 @@ export default function ProjectsAddUserForm({
           queryState={restQueryParams}
           noResultsMessage={t("noResultsMessage")}
           errorMessage={
-            <ErrorMessage t={t} tKey="professionalRegsitrationsErrorMessage" />
+            <ErrorMessage t={t} tKey="professionalRegistrationsErrorMessage" />
           }
           total={total}
           page={page}

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.test.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.test.tsx
@@ -1,0 +1,114 @@
+import { useStore } from "@/data/store";
+import { mockedUser } from "@/mocks/data/user";
+import { faker } from "@faker-js/faker";
+import { mock200Json } from "jest.utils";
+import { postAccreditations } from "@/app/actions/accreditations";
+import {
+  act,
+  commonAccessibilityTests,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "../../utils/testUtils";
+import AccreditationForm from "./AccreditationForm";
+
+jest.mock("@/app/actions/accreditations");
+
+const mockSetUser = jest.fn();
+
+const defaultUser = mockedUser({
+  profile_steps_completed: `
+    {"identity": {"dob": false, "score": 67, "last_name": true, "first_name": true}}
+  `,
+  profile_completed_at: null,
+});
+
+(useStore as unknown as jest.Mock).mockReturnValue([defaultUser, mockSetUser]);
+
+(postAccreditations as unknown as jest.Mock).mockResolvedValue(
+  mock200Json(1).json()
+);
+
+const mockOnSubmit = jest.fn();
+const mockOnCancel = jest.fn();
+
+const renderAccreditationFormComponent = () => {
+  return render(
+    <AccreditationForm
+      onSubmit={mockOnSubmit}
+      onCancel={mockOnCancel}
+      isPending={false}
+    />
+  );
+};
+
+describe("<AccreditationForm />", () => {
+  beforeEach(() => {
+    mockUseStore({
+      user: defaultUser,
+      setUser: mockSetUser,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(["Associated organisation name", "ID", "Issue date", "Expiry date"])(
+    "does not submit when %s is not defined",
+    async fieldName => {
+      renderAccreditationFormComponent();
+
+      const inputs = screen.getAllByRole("textbox");
+      inputs.forEach(input => {
+        if (
+          input.getAttribute("name") !==
+          fieldName.toLowerCase().replace(/\s/g, "_")
+        ) {
+          fireEvent.change(input, { target: { value: faker.string.sample() } });
+        }
+      });
+
+      const dateInputs = screen.getAllByRole("textbox", { name: /date/i });
+      dateInputs.forEach(input => {
+        if (
+          input.getAttribute("name") !==
+          fieldName.toLowerCase().replace(/\s/g, "_")
+        ) {
+          fireEvent.change(input, {
+            target: { value: faker.date.future().toISOString().split("T")[0] },
+          });
+        }
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /save/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+
+      act(() => {
+        fireEvent.submit(screen.getByRole("button", { name: /save/i }));
+      });
+
+      await waitFor(() => {
+        expect(mockOnSubmit).not.toHaveBeenCalled();
+      });
+    }
+  );
+
+  it("calls onCancel when cancel button is clicked", () => {
+    renderAccreditationFormComponent();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it("has no accessibility violations", async () => {
+    commonAccessibilityTests(renderAccreditationFormComponent());
+  });
+});

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import ButtonSave from "@/components/ButtonSave";
 import DateInput from "@/components/DateInput/DateInput";
 import Form from "@/components/Form";
@@ -12,6 +14,7 @@ import { Button, TextField } from "@mui/material";
 import dayjs from "dayjs";
 import Grid from "node_modules/@mui/material/esm/Grid/Grid";
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 
 interface AccreditationFormValues {
   associated_organisation_name: string | null;
@@ -27,25 +30,27 @@ interface AccreditationFormProps {
   initialValues?: Accreditation;
 }
 
+const NAMESPACE_TRANSLATION_ACCREDITATIONS_FORM =
+  "AccreditedResearcherRegistrationsForm";
+
 export default function AccreditationForm({
   onSubmit,
   isPending,
   onCancel,
   initialValues,
 }: AccreditationFormProps) {
+  const t = useTranslations(NAMESPACE_TRANSLATION_ACCREDITATIONS_FORM);
   const [user, setUser] = useStore(store => [store.config.user, store.setUser]);
 
   const schema = useMemo(
     () =>
       yup.object().shape({
-        associated_organisation_name: yup
-          .string()
-          .required("Associated organisation name is required"),
-        id_string: yup.string().required("ID string is required"),
+        associated_organisation_name: yup.string().required(t("requiredName")),
+        id_string: yup.string().required(t("requiredId")),
         issue_date: yup
           .string()
-          .required("Issue date is required")
-          .test("is-past", "Issue date must be in the past", value => {
+          .required(t("requiredIssueDate"))
+          .test("is-past", t("issueDateInvalid"), value => {
             return (
               dayjs(value).isBefore(dayjs()) ||
               dayjs(value).isSame(dayjs(), "day")
@@ -53,16 +58,12 @@ export default function AccreditationForm({
           }),
         expiry_date: yup
           .string()
-          .required("Expiry date is required")
-          .test(
-            "after-awarded",
-            "Expiry date must be after issue date",
-            (value, context) => {
-              const { issue_date } = context.parent;
-              return dayjs(value).isAfter(dayjs(issue_date));
-            }
-          )
-          .test("is-future", "Expiry date must be in the future", value => {
+          .required(t("requiredExpiryDate"))
+          .test("after-awarded", t("expiryDateInvalid"), (value, context) => {
+            const { issue_date } = context.parent;
+            return dayjs(value).isAfter(dayjs(issue_date));
+          })
+          .test("is-future", t("futureRequiredExpiryDate"), value => {
             return dayjs(value).isAfter(dayjs());
           }),
       }),
@@ -100,35 +101,35 @@ export default function AccreditationForm({
         <Grid size={{ xs: 12 }} key="associated_organisation_name">
           <FormControl
             name="associated_organisation_name"
-            label={"Associated Organisation Name"}
+            label={t("associatedOrganisationName")}
             renderField={props => <TextField {...props} />}
           />
         </Grid>
         <Grid size={{ xs: 12 }} key="id_string">
           <FormControl
             name="id_string"
-            label={"ID"}
+            label={t("id")}
             renderField={props => <TextField {...props} />}
           />
         </Grid>
         <Grid size={{ xs: 7 }} key="issue_date">
           <FormControl
             name="issue_date"
-            label={"Issue Date"}
+            label={t("issueDate")}
             renderField={props => <DateInput {...props} />}
           />
         </Grid>
         <Grid size={{ xs: 7 }} key="expiry_date">
           <FormControl
             name="expiry_date"
-            label={"Expiry Date"}
+            label={t("expiryDate")}
             renderField={props => <DateInput {...props} />}
           />
         </Grid>
       </Grid>
       <FormActions sx={{ display: "flex", justifyContent: "space-between" }}>
         <Button onClick={onCancel} variant="outlined">
-          Cancel
+          {t("cancel")}
         </Button>
         <ButtonSave type="submit" disabled={isPending} />
       </FormActions>

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
@@ -39,7 +39,7 @@ export default function AccreditationForm({
   initialValues,
 }: AccreditationFormProps) {
   const t = useTranslations(NAMESPACE_TRANSLATION_ACCREDITATIONS_FORM);
-  const [user, setUser] = useStore(store => [store.config.user, store.setUser]);
+  const [user] = useStore(store => [store.config.user, store.setUser]);
 
   const schema = useMemo(
     () =>

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
@@ -8,7 +8,7 @@ import FormControl from "../../components/FormControlWrapper";
 import yup from "@/config/yup";
 import { useStore } from "@/data/store";
 import { PostAccreditationsPayload } from "@/services/accreditations/types";
-import { ResearcherAccreditation, Accreditation } from "@/types/application";
+import { Accreditation } from "@/types/application";
 import { formatDBDateTime } from "@/utils/date";
 import { Button, TextField } from "@mui/material";
 import dayjs from "dayjs";

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
@@ -1,0 +1,137 @@
+import ButtonSave from "@/components/ButtonSave";
+import DateInput from "@/components/DateInput/DateInput";
+import Form from "@/components/Form";
+import FormActions from "@/components/FormActions/FormActions";
+import FormControl from "../../components/FormControlWrapper";
+import yup from "@/config/yup";
+import { useStore } from "@/data/store";
+import { PostAccreditationsPayload } from "@/services/accreditations/types";
+import { ResearcherAccreditation, Accreditation } from "@/types/application";
+import { formatDBDateTime } from "@/utils/date";
+import { Button, TextField } from "@mui/material";
+import dayjs from "dayjs";
+import Grid from "node_modules/@mui/material/esm/Grid/Grid";
+import { useMemo } from "react";
+
+interface AccreditationFormValues {
+  associated_organisation_name: string | null;
+  id_string: string;
+  issue_date: string;
+  expiry_date: string;
+}
+
+interface AccreditationFormProps {
+  onSubmit: (values: PostAccreditationsPayload) => void;
+  isPending: boolean;
+  onCancel: () => void;
+  initialValues?: Accreditation;
+}
+
+export default function AccreditationForm({
+  onSubmit,
+  isPending,
+  onCancel,
+  initialValues,
+}: AccreditationFormProps) {
+  const [user, setUser] = useStore(store => [store.config.user, store.setUser]);
+
+  const schema = useMemo(
+    () =>
+      yup.object().shape({
+        associated_organisation_name: yup
+          .string()
+          .required("Associated organisation name is required"),
+        id_string: yup.string().required("ID string is required"),
+        issue_date: yup
+          .string()
+          .required("Issue date is required")
+          .test("is-past", "Issue date must be in the past", value => {
+            return (
+              dayjs(value).isBefore(dayjs()) ||
+              dayjs(value).isSame(dayjs(), "day")
+            );
+          }),
+        expiry_date: yup
+          .string()
+          .required("Expiry date is required")
+          .test(
+            "after-awarded",
+            "Expiry date must be after issue date",
+            (value, context) => {
+              const { issue_date } = context.parent;
+              return dayjs(value).isAfter(dayjs(issue_date));
+            }
+          )
+          .test("is-future", "Expiry date must be in the future", value => {
+            return dayjs(value).isAfter(dayjs());
+          }),
+      }),
+    []
+  );
+
+  const formOptions = {
+    defaultValues: {
+      associated_organisation_name:
+        initialValues?.associated_organisation_name || "",
+      id_string: initialValues?.id_string || "",
+      issue_date: initialValues?.issue_date || "",
+      expiry_date: initialValues?.expiry_date || "",
+    },
+  };
+
+  const handleSubmit = (fields: AccreditationFormValues) => {
+    const formattedFields = {
+      ...fields,
+      associated_organisation_name: fields.associated_organisation_name || null,
+      id_string: fields.id_string,
+      issue_date: formatDBDateTime(fields.issue_date),
+      expiry_date: formatDBDateTime(fields.expiry_date),
+    };
+    onSubmit(formattedFields);
+  };
+
+  return (
+    <Form
+      onSubmit={handleSubmit}
+      schema={schema}
+      {...formOptions}
+      key={user?.id}>
+      <Grid container rowSpacing={3}>
+        <Grid size={{ xs: 12 }} key="associated_organisation_name">
+          <FormControl
+            name="associated_organisation_name"
+            label={"Associated Organisation Name"}
+            renderField={props => <TextField {...props} />}
+          />
+        </Grid>
+        <Grid size={{ xs: 12 }} key="id_string">
+          <FormControl
+            name="id_string"
+            label={"ID"}
+            renderField={props => <TextField {...props} />}
+          />
+        </Grid>
+        <Grid size={{ xs: 7 }} key="issue_date">
+          <FormControl
+            name="issue_date"
+            label={"Issue Date"}
+            renderField={props => <DateInput {...props} />}
+          />
+        </Grid>
+        <Grid size={{ xs: 7 }} key="expiry_date">
+          <FormControl
+            name="expiry_date"
+            label={"Expiry Date"}
+            renderField={props => <DateInput {...props} />}
+          />
+        </Grid>
+      </Grid>
+      <FormActions sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Button onClick={onCancel} variant="outlined">
+          Cancel
+        </Button>
+        <ButtonSave type="submit" disabled={isPending} />
+      </FormActions>
+    </Form>
+  );
+}

--- a/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditationForm.tsx
@@ -10,9 +10,8 @@ import { useStore } from "@/data/store";
 import { PostAccreditationsPayload } from "@/services/accreditations/types";
 import { Accreditation } from "@/types/application";
 import { formatDBDateTime } from "@/utils/date";
-import { Button, TextField } from "@mui/material";
+import { Button, TextField, Grid } from "@mui/material";
 import dayjs from "dayjs";
-import Grid from "node_modules/@mui/material/esm/Grid/Grid";
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.test.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.test.tsx
@@ -1,0 +1,90 @@
+import { useStore } from "@/data/store";
+import { mockedTraining, mockedUser } from "@/mocks/data/user";
+import { faker } from "@faker-js/faker";
+import { mock200Json } from "jest.utils";
+import { useRouter } from "next/navigation";
+import {
+  getAccreditations,
+  postAccreditations,
+} from "@/app/actions/accreditations";
+import { EntityType } from "../../types/api";
+import {
+  act,
+  commonAccessibilityTests,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "../../utils/testUtils";
+import AccreditatedResearchRegs from "./AccreditedResearcherRegs";
+
+const mockPush = jest.fn();
+
+(useRouter as jest.Mock).mockReturnValue({
+  push: mockPush,
+});
+
+jest.mock("@/app/actions/accreditations");
+jest.mock("@/data/store");
+
+const mockSetUser = jest.fn();
+
+const defaultUser = mockedUser({
+  profile_steps_completed: `
+    {"identity": {"dob": false, "score": 67, "last_name": true, "first_name": true}}
+  `,
+  profile_completed_at: null,
+});
+
+(useStore as unknown as jest.Mock).mockReturnValue([defaultUser, mockSetUser]);
+
+(getAccreditations as jest.Mock).mockResolvedValue({
+  data: [mockedTraining],
+});
+(postAccreditations as unknown as jest.Mock).mockResolvedValue(
+  mock200Json(1).json()
+);
+const renderTrainingComponent = () => {
+  return render(<AccreditatedResearchRegs variant={EntityType.USER} />);
+};
+
+describe("<AccreditatedResearchRegs />", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([/Associated organisation name/i, /ID/i])(
+    "does not submit when %s is not defined",
+    async fieldName => {
+      renderTrainingComponent();
+
+      const addButton = screen.getByRole("button", {
+        name: /add accreditated research registration/i,
+      });
+      fireEvent.click(addButton);
+
+      const input = screen.getByRole("textbox", { name: fieldName });
+      fireEvent.change(input, { target: { value: faker.string.sample() } });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /save/i })
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+
+      act(() => {
+        fireEvent.submit(screen.getByRole("button", { name: /Save/i }));
+      });
+
+      await waitFor(() => {
+        expect(postAccreditations).not.toHaveBeenCalled();
+      });
+    }
+  );
+
+  it("has no accessibility violations", async () => {
+    commonAccessibilityTests(renderTrainingComponent());
+  });
+});

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.test.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.test.tsx
@@ -59,7 +59,7 @@ describe("<AccreditatedResearchRegs />", () => {
       renderTrainingComponent();
 
       const addButton = screen.getByRole("button", {
-        name: /add accreditated research registration/i,
+        name: /add researcher accreditation/i,
       });
       fireEvent.click(addButton);
 

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -71,12 +71,10 @@ export default function AccreditedResearcherRegs({
     useMutation(postAccreditationsQuery(registryId));
 
   const { mutateAsync: mutateUpdateAsync, ...putAccreditationsQueryState } =
-    useMutation(putAccreditationsQuery(selectedAccreditation?.id));
+    useMutation(putAccreditationsQuery(registryId));
 
   const { mutateAsync: mutateDeleteAsync, ...deleteAccreditationsQueryState } =
-    useMutation(
-      deleteAccreditationsQuery({ id: selectedAccreditation?.id, registryId })
-    );
+    useMutation(deleteAccreditationsQuery(registryId));
 
   const onSubmit = useCallback(
     async (accreditation: PostAccreditationsPayload) => {

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -58,6 +58,7 @@ export default function AccreditedResearcherRegs({
     ...getAccreditationsQuery(registryId),
   });
 
+  //states
   const { mutateAsync, isPending, ...postAccreditationsQueryState } =
     useMutation(postAccreditationsQuery(registryId));
 

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -97,11 +97,10 @@ export default function AccreditedResearcherRegs({
 
       if (selectedAccreditation) {
         await mutateUpdateAsync({ id: selectedAccreditation.id, ...payload });
-        await onSubmit(payload);
       } else {
         await mutateAsync(payload);
-        await onSubmit(payload);
       }
+      await onSubmit(payload);
       refetchAccreditations();
       handleCloseModal();
     },

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -45,7 +45,8 @@ interface AccreditationsProps {
   getHistories?: () => StoreUserHistories | undefined;
 }
 
-const NAMESPACE_TRANSLATION_TRAINING = "AccreditedResearcherRegistrations";
+const NAMESPACE_TRANSLATION_ACCREDITATIONS =
+  "AccreditedResearcherRegistrations";
 
 export default function AccreditedResearcherRegs({
   variant,
@@ -57,7 +58,7 @@ export default function AccreditedResearcherRegs({
   const [selectedAccreditation, setSelectedAccreditation] = useState<
     Accreditation | undefined
   >(undefined);
-  const t = useTranslations(NAMESPACE_TRANSLATION_TRAINING);
+  const t = useTranslations(NAMESPACE_TRANSLATION_ACCREDITATIONS);
 
   const {
     data: accreditationsData,
@@ -131,7 +132,7 @@ export default function AccreditedResearcherRegs({
             onClick={() => handleOpenModal(accreditation)}
             sx={{ color: "secondary.main" }}
             icon={<CreateOutlinedIcon sx={{ color: "secondary.main" }} />}>
-            View or Edit
+            {t("viewOrEditAccreditation")}
           </ActionMenuItem>
 
           <ActionMenuItem
@@ -140,7 +141,7 @@ export default function AccreditedResearcherRegs({
             }}
             sx={{ color: "error.main" }}
             icon={<DeleteOutlineOutlinedIcon sx={{ color: "error.main" }} />}>
-            Delete
+            {t("deleteAccreditation")}
           </ActionMenuItem>
         </ActionMenu>
       );
@@ -210,24 +211,24 @@ export default function AccreditedResearcherRegs({
 
   const columns = [
     {
-      header: "Associated Organisation",
+      header: t("associatedOrganisationName"),
       accessorKey: "associated_organisation_name",
       flex: 1,
     },
     {
-      header: "ID",
+      header: t("id"),
       accessorKey: "id_string",
       flex: 1,
     },
     {
-      header: "Date of Issue",
+      header: t("issueDate"),
       accessorKey: "issue_date",
       flex: 1,
       cell: ({ row }: { row: { original: Accreditation } }) =>
         formatShortDate(row.original.issue_date),
     },
     {
-      header: "Expiry Date",
+      header: t("expiryDate"),
       accessorKey: "expiry_date",
       flex: 1,
       cell: ({ row }: { row: { original: Accreditation } }) =>
@@ -244,8 +245,6 @@ export default function AccreditedResearcherRegs({
         ]
       : []),
   ];
-
-  console.log(registryId, "registryId");
 
   return (
     <>

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -97,6 +97,7 @@ export default function AccreditedResearcherRegs({
 
       if (selectedAccreditation) {
         await mutateUpdateAsync({ id: selectedAccreditation.id, ...payload });
+        await onSubmit(payload);
       } else {
         await mutateAsync(payload);
         await onSubmit(payload);

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -9,17 +9,9 @@ import {
   postAccreditationsQuery,
   putAccreditationsQuery,
 } from "@/services/accreditations";
-import {
-  Accreditations,
-  //Accreditations
-  PostAccreditationsPayload,
-} from "@/services/accreditations/types";
+import { PostAccreditationsPayload } from "@/services/accreditations/types";
 import { EntityType } from "../../types/api";
-import {
-  //ResearcherAccreditation,
-  User,
-  Accreditation,
-} from "@/types/application";
+import { User, Accreditation } from "@/types/application";
 import { StoreUserHistories } from "@/data/store";
 import { useTranslations } from "next-intl";
 import { Button, Link, Typography } from "@mui/material";
@@ -29,10 +21,8 @@ import { AddIcon } from "@/consts/icons";
 import FormModal from "@/components/FormModal";
 import { useCallback, useState } from "react";
 import AccreditationForm from "./AccreditationForm";
-
 import ErrorMessage from "@/components/ErrorMessage/ErrorMessage";
 import useQueryAlerts from "@/hooks/useQueryAlerts/useQueryAlerts";
-
 import ActionMenuItem from "@/components/ActionMenu/ActionMenuItem";
 import { ActionMenu } from "@/components/ActionMenu";
 import useQueryConfirmAlerts from "@/hooks/useQueryConfirmAlerts";
@@ -54,11 +44,11 @@ export default function AccreditedResearcherRegs({
   setHistories,
   getHistories,
 }: AccreditationsProps) {
+  const t = useTranslations(NAMESPACE_TRANSLATION_ACCREDITATIONS);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedAccreditation, setSelectedAccreditation] = useState<
     Accreditation | undefined
   >(undefined);
-  const t = useTranslations(NAMESPACE_TRANSLATION_ACCREDITATIONS);
 
   const {
     data: accreditationsData,
@@ -106,10 +96,8 @@ export default function AccreditedResearcherRegs({
       };
 
       if (selectedAccreditation) {
-        // Update existing accreditation
         await mutateUpdateAsync({ id: selectedAccreditation.id, ...payload });
       } else {
-        // Create new accreditation
         await mutateAsync(payload);
         await onSubmit(payload);
       }

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import Table from "@/components/Table";
+import { formatDBDateTime, formatShortDate } from "@/utils/date";
+import {
+  deleteAccreditationsQuery,
+  getAccreditationsQuery,
+  postAccreditationsQuery,
+  putAccreditationsQuery,
+} from "@/services/accreditations";
+import {
+  Accreditations,
+  //Accreditations
+  PostAccreditationsPayload,
+} from "@/services/accreditations/types";
+import { EntityType } from "../../types/api";
+import {
+  //ResearcherAccreditation,
+  User,
+  Accreditation,
+} from "@/types/application";
+import { StoreUserHistories } from "@/data/store";
+import { useTranslations } from "next-intl";
+import { Button, Link, Typography } from "@mui/material";
+import CreateOutlinedIcon from "@mui/icons-material/CreateOutlined";
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import { AddIcon } from "@/consts/icons";
+import FormModal from "@/components/FormModal";
+import { useCallback, useState } from "react";
+import AccreditationForm from "./AccreditationForm";
+
+import ErrorMessage from "@/components/ErrorMessage/ErrorMessage";
+import useQueryAlerts from "@/hooks/useQueryAlerts/useQueryAlerts";
+
+import ActionMenuItem from "@/components/ActionMenu/ActionMenuItem";
+import { ActionMenu } from "@/components/ActionMenu";
+import useQueryConfirmAlerts from "@/hooks/useQueryConfirmAlerts";
+
+interface AccreditationsProps {
+  variant: EntityType;
+  user: User;
+  registryId: number;
+  setHistories?: (histories: StoreUserHistories) => void;
+  getHistories?: () => StoreUserHistories | undefined;
+}
+
+const NAMESPACE_TRANSLATION_TRAINING = "AccreditedResearcherRegistrations";
+
+export default function AccreditedResearcherRegs({
+  variant,
+  registryId,
+  setHistories,
+  getHistories,
+}: AccreditationsProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedAccreditation, setSelectedAccreditation] = useState<
+    Accreditation | undefined
+  >(undefined);
+  const t = useTranslations(NAMESPACE_TRANSLATION_TRAINING);
+
+  const {
+    data: accreditationsData,
+    refetch: refetchAccreditations,
+    ...accreditationsQueryState
+  } = useQuery({
+    ...getAccreditationsQuery(registryId),
+  });
+
+  const { mutateAsync, isPending, ...postAccreditationsQueryState } =
+    useMutation(postAccreditationsQuery(registryId));
+
+  const { mutateAsync: mutateUpdateAsync, ...putAccreditationsQueryState } =
+    useMutation(putAccreditationsQuery(selectedAccreditation?.id));
+
+  const { mutateAsync: mutateDeleteAsync, ...deleteAccreditationsQueryState } =
+    useMutation(
+      deleteAccreditationsQuery({ id: selectedAccreditation?.id, registryId })
+    );
+
+  const onSubmit = useCallback(
+    async (accreditation: PostAccreditationsPayload) => {
+      try {
+        const histories = getHistories();
+        const updatedHistories = {
+          ...histories,
+          accreditations: [...histories.accreditations, accreditation],
+        };
+        if (updatedHistories) {
+          setHistories(updatedHistories);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [getHistories, setHistories]
+  );
+
+  const handleSubmit = useCallback(
+    async (accreditation: PostAccreditationsPayload) => {
+      const payload = {
+        ...accreditation,
+        associated_organisation_name:
+          accreditation.associated_organisation_name ?? null,
+        issue_date: formatDBDateTime(accreditation.issue_date),
+        expiry_date: formatDBDateTime(accreditation.expiry_date),
+      };
+
+      if (selectedAccreditation) {
+        // Update existing accreditation
+        await mutateUpdateAsync({ id: selectedAccreditation.id, ...payload });
+      } else {
+        // Create new accreditation
+        await mutateAsync(payload);
+        await onSubmit(payload);
+      }
+      refetchAccreditations();
+      handleCloseModal();
+    },
+    [mutateAsync, mutateUpdateAsync, onSubmit, selectedAccreditation]
+  );
+
+  const handleDelete = async (id: number) => {
+    showDeleteConfirm(id);
+  };
+
+  const renderActions = useCallback(
+    (accreditation: Accreditation) => {
+      return (
+        <ActionMenu
+          aria-label={`Actions for ${accreditation.associated_organisation_name}`}>
+          <ActionMenuItem
+            onClick={() => handleOpenModal(accreditation)}
+            sx={{ color: "secondary.main" }}
+            icon={<CreateOutlinedIcon sx={{ color: "secondary.main" }} />}>
+            View or Edit
+          </ActionMenuItem>
+
+          <ActionMenuItem
+            onClick={() => {
+              handleDelete(accreditation.id);
+            }}
+            sx={{ color: "error.main" }}
+            icon={<DeleteOutlineOutlinedIcon sx={{ color: "error.main" }} />}>
+            Delete
+          </ActionMenuItem>
+        </ActionMenu>
+      );
+    },
+    [registryId, handleDelete]
+  );
+
+  const handleOpenModal = useCallback((accreditation?: Accreditation) => {
+    setSelectedAccreditation(accreditation);
+    setIsModalOpen(true);
+  }, []);
+
+  const handleAddAccreditation = useCallback(() => {
+    handleOpenModal();
+  }, [handleOpenModal]);
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedAccreditation(undefined);
+  };
+
+  useQueryAlerts(
+    selectedAccreditation
+      ? putAccreditationsQueryState
+      : postAccreditationsQueryState,
+    {
+      onSuccess: () => {
+        handleCloseModal();
+      },
+      errorAlertProps: {
+        text: (
+          <ErrorMessage
+            t={t}
+            key={
+              selectedAccreditation
+                ? "updateAccreditationError"
+                : "postAccreditationError"
+            }
+          />
+        ),
+      },
+      successAlertProps: {
+        text: selectedAccreditation
+          ? t("updateAccreditationSuccess")
+          : t("postAccreditationSuccess"),
+      },
+    }
+  );
+
+  const showDeleteConfirm = useQueryConfirmAlerts<number>(
+    deleteAccreditationsQueryState,
+    {
+      onSuccess: () => refetchAccreditations(),
+      confirmAlertProps: {
+        onConfirm: async id => {
+          await mutateDeleteAsync(id as number);
+        },
+      },
+      errorAlertProps: {
+        text: <ErrorMessage t={t} tKey="errorDeleteMessage" />,
+      },
+      successAlertProps: {
+        text: t("successDeleteMessage"),
+      },
+    }
+  );
+
+  const columns = [
+    {
+      header: "Associated Organisation",
+      accessorKey: "associated_organisation_name",
+      flex: 1,
+    },
+    {
+      header: "ID",
+      accessorKey: "id_string",
+      flex: 1,
+    },
+    {
+      header: "Date of Issue",
+      accessorKey: "issue_date",
+      flex: 1,
+      cell: ({ row }: { row: { original: Accreditation } }) =>
+        formatShortDate(row.original.issue_date),
+    },
+    {
+      header: "Expiry Date",
+      accessorKey: "expiry_date",
+      flex: 1,
+      cell: ({ row }: { row: { original: Accreditation } }) =>
+        formatShortDate(row.original.expiry_date),
+    },
+    ...(variant === EntityType.USER
+      ? [
+          {
+            header: "",
+            accessorKey: "actions",
+            cell: ({ row }: { row: { original: Accreditation } }) =>
+              renderActions(row.original),
+          },
+        ]
+      : []),
+  ];
+
+  console.log(registryId, "registryId");
+
+  return (
+    <>
+      <Typography variant="h3" sx={{ mb: 1 }}>
+        {t("accreditationTitle")}
+      </Typography>
+      <Link
+        sx={{ display: "block", mb: 1 }}
+        href="https://uksa.statisticsauthority.gov.uk/digitaleconomyact-research-statistics/better-useofdata-for-research-information-for-researchers/list-of-accredited-researchers-and-research-projects-under-the-research-strand-of-the-digital-economy-act/">
+        {t("publicRegisterLink")}
+      </Link>
+      <Table
+        data={accreditationsData?.data?.data ?? []}
+        columns={columns}
+        queryState={accreditationsQueryState}
+        total={accreditationsData?.data?.data.length ?? 0}
+        noResultsMessage={t("noResultsMessage")}
+        sx={{ maxWidth: "100%" }}
+      />
+      {variant === EntityType.USER && (
+        <>
+          <Button
+            onClick={handleAddAccreditation}
+            variant="outlined"
+            color="primary"
+            startIcon={<AddIcon />}
+            sx={{ mt: 2 }}>
+            {t("buttonText")}
+          </Button>
+
+          <FormModal
+            open={isModalOpen}
+            heading={
+              selectedAccreditation
+                ? t("editAccreditation")
+                : t("addAccreditation")
+            }>
+            <AccreditationForm
+              onSubmit={handleSubmit}
+              isPending={isPending || putAccreditationsQueryState.isPending}
+              onCancel={handleCloseModal}
+              initialValues={selectedAccreditation}
+            />
+          </FormModal>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
+++ b/src/organisms/AccreditedResearcherRegs/AccreditedResearcherRegs.tsx
@@ -58,7 +58,6 @@ export default function AccreditedResearcherRegs({
     ...getAccreditationsQuery(registryId),
   });
 
-  //states
   const { mutateAsync, isPending, ...postAccreditationsQueryState } =
     useMutation(postAccreditationsQuery(registryId));
 

--- a/src/organisms/AccreditedResearcherRegs/index.ts
+++ b/src/organisms/AccreditedResearcherRegs/index.ts
@@ -1,0 +1,3 @@
+import AccreditedResearcherRegs from "./AccreditedResearcherRegs";
+
+export default AccreditedResearcherRegs;

--- a/src/organisms/UserTrainingAccreditations/UserTrainingAccreditations.tsx
+++ b/src/organisms/UserTrainingAccreditations/UserTrainingAccreditations.tsx
@@ -20,7 +20,6 @@ export default function UserTrainingAccreditations({
       professionalRegistrations:
         state.config.histories?.professionalRegistrations || [],
     }));
-  console.log(user?.registry_id, "user?.registry_id");
   return (
     <>
       <PageSection>

--- a/src/organisms/UserTrainingAccreditations/UserTrainingAccreditations.tsx
+++ b/src/organisms/UserTrainingAccreditations/UserTrainingAccreditations.tsx
@@ -3,6 +3,7 @@ import { PageSection } from "../../modules";
 import ProfessionalRegistrations from "../../modules/ProfessionalRegistrations";
 import { EntityType } from "../../types/api";
 import Training from "../Training";
+import AccreditedResearcherRegs from "../AccreditedResearcherRegs";
 
 interface UserTrainingAccreditationsProps {
   variant: EntityType;
@@ -19,11 +20,18 @@ export default function UserTrainingAccreditations({
       professionalRegistrations:
         state.config.histories?.professionalRegistrations || [],
     }));
-
+  console.log(user?.registry_id, "user?.registry_id");
   return (
     <>
       <PageSection>
         <Training variant={variant} user={user} />
+      </PageSection>
+      <PageSection>
+        <AccreditedResearcherRegs
+          variant={variant}
+          user={user}
+          registryId={user.registry_id}
+        />
       </PageSection>
       <PageSection sx={{ mb: 3 }}>
         <ProfessionalRegistrations

--- a/src/services/accreditations/deleteAccreditationsQuery.ts
+++ b/src/services/accreditations/deleteAccreditationsQuery.ts
@@ -3,28 +3,24 @@ import { MutationOptions } from "@/types/requests";
 import { UseMutationOptions } from "@tanstack/react-query";
 
 export default function deleteAccreditationsQuery(
-  // registryId: number,
-  // id: number,
+  registryId: number,
   options?: MutationOptions
 ) {
   return {
     mutationKey: [
       "deleteAccreditations",
-      // registryId,
-      // id,
+      registryId,
       ...(options?.mutationKeySuffix || []),
     ],
-    mutationFn: ({ id, registryId }: { id: number; registryId: number }) => {
-      console.log(id, "id");
-      console.log(registryId, "registryId2");
-      return deleteAccreditations(id, registryId, {
+    mutationFn: (id: number) =>
+      deleteAccreditations(registryId, id, {
         error: { message: "deleteAccreditations" },
         ...options?.responseOptions,
-      });
-    },
+      }),
     ...options,
   } as UseMutationOptions<
     Awaited<ReturnType<typeof deleteAccreditations>>,
-    Error
+    Error,
+    number
   >;
 }

--- a/src/services/accreditations/deleteAccreditationsQuery.ts
+++ b/src/services/accreditations/deleteAccreditationsQuery.ts
@@ -1,0 +1,30 @@
+import deleteAccreditations from "@/app/actions/accreditations/deleteAccreditations";
+import { MutationOptions } from "@/types/requests";
+import { UseMutationOptions } from "@tanstack/react-query";
+
+export default function deleteAccreditationsQuery(
+  // registryId: number,
+  // id: number,
+  options?: MutationOptions
+) {
+  return {
+    mutationKey: [
+      "deleteAccreditations",
+      // registryId,
+      // id,
+      ...(options?.mutationKeySuffix || []),
+    ],
+    mutationFn: ({ id, registryId }: { id: number; registryId: number }) => {
+      console.log(id, "id");
+      console.log(registryId, "registryId2");
+      return deleteAccreditations(id, registryId, {
+        error: { message: "deleteAccreditations" },
+        ...options?.responseOptions,
+      });
+    },
+    ...options,
+  } as UseMutationOptions<
+    Awaited<ReturnType<typeof deleteAccreditations>>,
+    Error
+  >;
+}

--- a/src/services/accreditations/getAccreditationsQuery.ts
+++ b/src/services/accreditations/getAccreditationsQuery.ts
@@ -18,5 +18,5 @@ export default function getAccreditationsQuery(
         ...options?.responseOptions,
       }),
     ...options,
-  } as UseQueryOptions<ReturnType<typeof getAccreditations>>;
+  } as UseQueryOptions<Awaited<ReturnType<typeof getAccreditations>>>;
 }

--- a/src/services/accreditations/index.ts
+++ b/src/services/accreditations/index.ts
@@ -1,3 +1,11 @@
-import getAccreditationsQuery from "@/services/accreditations/getAccreditationsQuery";
+import getAccreditationsQuery from "./getAccreditationsQuery";
+import putAccreditationsQuery from "./putAccreditationsQuery";
+import deleteAccreditationsQuery from "./deleteAccreditationsQuery";
+import postAccreditationsQuery from "./postAccreditationsQuery";
 
-export { getAccreditationsQuery };
+export {
+  getAccreditationsQuery,
+  putAccreditationsQuery,
+  deleteAccreditationsQuery,
+  postAccreditationsQuery,
+};

--- a/src/services/accreditations/postAccreditationsQuery.ts
+++ b/src/services/accreditations/postAccreditationsQuery.ts
@@ -1,0 +1,13 @@
+import postAccreditations from "@/app/actions/accreditations/postAccreditations";
+import { PostAccreditationsPayload } from "./types";
+
+export default function postAccreditationsQuery(registryId: number) {
+  return {
+    mutationKey: ["postAccreditations", registryId],
+    mutationFn: (payload: PostAccreditationsPayload) => {
+      return postAccreditations(registryId, payload, {
+        error: { message: "postAccreditationError" },
+      });
+    },
+  };
+}

--- a/src/services/accreditations/putAccreditationsQuery.ts
+++ b/src/services/accreditations/putAccreditationsQuery.ts
@@ -1,0 +1,14 @@
+import putAccreditations from "@/app/actions/accreditations/putAccreditations";
+import { PutAccreditationsPayload } from "./types";
+
+export default function putAccreditationsQuery(registryId: number) {
+  return {
+    mutationKey: ["putAccreditationsQuery", registryId],
+    mutationFn: (payload: PutAccreditationsPayload) =>
+      putAccreditations(registryId, payload, {
+        error: {
+          message: "submitError",
+        },
+      }),
+  };
+}

--- a/src/services/accreditations/putAccreditationsQuery.ts
+++ b/src/services/accreditations/putAccreditationsQuery.ts
@@ -4,8 +4,8 @@ import { PutAccreditationsPayload } from "./types";
 export default function putAccreditationsQuery(registryId: number) {
   return {
     mutationKey: ["putAccreditationsQuery", registryId],
-    mutationFn: (payload: PutAccreditationsPayload) =>
-      putAccreditations(registryId, payload, {
+    mutationFn: (payload: PutAccreditationsPayload & { id: number }) =>
+      putAccreditations(payload.id, registryId, payload, {
         error: {
           message: "submitError",
         },

--- a/src/services/accreditations/types.ts
+++ b/src/services/accreditations/types.ts
@@ -2,4 +2,33 @@ import { ResearcherAccreditation } from "@/types/application";
 
 type AccreditationsResponse = ResearcherAccreditation[];
 
-export type { AccreditationsResponse };
+interface Accreditations {
+  id: number;
+  registry_id: number;
+  associated_organisation_name: string | null;
+  id_string: string;
+  issue_date: string;
+  expiry_date: string;
+}
+
+interface PostAccreditationsPayload {
+  associated_organisation_name: string | null;
+  id_string: string;
+  issue_date: string;
+  expiry_date: string;
+}
+
+type PostAccreditationsResponse = number;
+
+type PutAccreditationsPayload = Partial<ResearcherAccreditation>;
+
+type PutAccreditationsResponse = ResearcherAccreditation;
+
+export type {
+  AccreditationsResponse,
+  Accreditations,
+  PostAccreditationsPayload,
+  PutAccreditationsPayload,
+  PutAccreditationsResponse,
+  PostAccreditationsResponse,
+};

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -344,6 +344,14 @@ interface ResearcherAccreditation {
   awarded_locale: string;
 }
 
+interface Accreditation {
+  id: number;
+  associated_organisation_name: string;
+  id_string: string;
+  issue_date: string;
+  expiry_date: string;
+}
+
 interface ResearcherTraining {
   awarded_at: string;
   provider: string;
@@ -611,6 +619,7 @@ export type {
   ProjectRole,
   ProjectUser,
   ResearcherAccreditation,
+  Accreditation,
   ResearcherAffiliation,
   ResearcherEducation,
   ResearcherEmployment,

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -220,8 +220,6 @@ type User = WithModelState<{
   role?: string;
   location?: string;
   status: Status;
-  declaration_signed?: boolean;
-  uksa_registered?: boolean;
   rules?: RuleState[];
   t_and_c_agreed?: boolean;
   invited_by?: User;


### PR DESCRIPTION
## Screenshots / videos (if relevant)

**User View**

https://github.com/user-attachments/assets/804b281a-32b0-443a-beec-6aef8a98130d


**Custodian View**

<img width="2728" height="1622" alt="image" src="https://github.com/user-attachments/assets/0a38682e-e190-488c-a5a8-a6c58ea78e56" />


## Describe your changes
Replace the UK Stats Authority tick boxes on the "training and accreditations" tab with a "Accredited Researcher Registrations" table. This table is editable in the user view but read only in the custodian view. This PR covers both tickets 2622 and 2620.

## Issue ticket link
https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2622

https://hdruk.atlassian.net/jira/software/projects/REGISTRY/boards/66?jql=assignee%20%3D%20712020%3A863b2441-cf22-48cb-afd2-a6006b4426b3&selectedIssue=REGISTRY-2620

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [X] Commits are described as "(chore|fix|feature|test|maintenance): description"
