### PR TITLE
feat(REGISTRY-2900): prevent changing affiliation email

### DIFF
--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -302,7 +302,7 @@ jobs:
           repository: HDRUK/safepeopleregistry-api
           path: safepeopleregistry-api
           token: ${{ steps.generate-deployment-token.outputs.token }}
-          ref: ${{ github.event.inputs.api_branch || 'dev' }}
+          ref: feat/registry-2899-prevent-changing-affiliation-email
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -302,7 +302,7 @@ jobs:
           repository: HDRUK/safepeopleregistry-api
           path: safepeopleregistry-api
           token: ${{ steps.generate-deployment-token.outputs.token }}
-          ref: feat/registry-2899-prevent-changing-affiliation-email
+          ref: ${{ github.event.inputs.api_branch || 'dev' }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/app/[locale]/(logged-in)/user/profile/components/AffiliationsForm/AffiliationsForm.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/AffiliationsForm/AffiliationsForm.tsx
@@ -403,6 +403,7 @@ export default function AffiliationsForm({
                         </Box>
                       )
                     }
+                    disabled={!!initialValues}
                   />
                 </Grid>
               )}

--- a/src/app/[locale]/(logged-in)/user/profile/components/AffiliationsForm/AffiliationsForm.tsx
+++ b/src/app/[locale]/(logged-in)/user/profile/components/AffiliationsForm/AffiliationsForm.tsx
@@ -403,7 +403,7 @@ export default function AffiliationsForm({
                         </Box>
                       )
                     }
-                    disabled={!!initialValues}
+                    disabled={!!initialValues && !!initialValues.email}
                   />
                 </Grid>
               )}


### PR DESCRIPTION
## Screenshots / videos (if relevant)

## Describe your changes
Don't allow users to change their Affiliation email if they've already set one. This is to avoid the tangle of knock-on effects that would ensue given the verified email is a key item the Orgs and Custodians rely on to establish identity.

Do allow one case, whereby the user changes their Affiliation to be Current, and have not previously set an email address. The modal would then show the email field, so to avoid confusion about why that would show but not be editable, we allow edits in that case. This is safe since before this point they will not have a verified email, and so the email verification consequent logic will all be fine.

Pairs with https://github.com/HDRUK/safepeopleregistry-api/pull/777

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-2900

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
