### PR TITLE
fix(REGISTRY-2281): Fix text in automated flags screen

### DIFF
--- a/mocks/data/organisation.ts
+++ b/mocks/data/organisation.ts
@@ -229,7 +229,7 @@ const mockedOrganisation = (
         rule: "DelegateCheck",
         status: "failed",
         conditions: {
-          path: "delegate_contacts",
+          path: "delegates",
           expects: {
             minimum: 1,
           },

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1980,7 +1980,7 @@
       }
     },
     "DelegateCheck": {
-      "delegate_contacts": "Delegate contacts"
+      "delegates": "Delegate contacts"
     },
     "IdentityVerification": {
       "registry": {


### PR DESCRIPTION
## Screenshots / videos (if relevant)

## Describe your changes
Fix the translation path to correctly display text after https://github.com/HDRUK/safepeopleregistry-api/pull/782 changed it

## Issue ticket link
partially addresses https://hdruk.atlassian.net/browse/REGISTRY-2281

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
